### PR TITLE
Add in explicit documentation about our unsafe usage.

### DIFF
--- a/devel/benches/input.rs
+++ b/devel/benches/input.rs
@@ -212,9 +212,9 @@ macro_rules! native_op {
 }
 
 pub fn bnum_from_u128(x: u128, y: u128) -> U256 {
-    let buf = [x.to_le(), y.to_le()];
+    let buf = [x.to_le_bytes(), y.to_le_bytes()];
     // SAFETY: plain old data
-    let slc = unsafe { mem::transmute::<[u128; 2], [u8; 32]>(buf) };
+    let slc = unsafe { mem::transmute::<[[u8; 16]; 2], [u8; 32]>(buf) };
     U256::from_le_slice(&slc).unwrap()
 }
 

--- a/src/math/div.rs
+++ b/src/math/div.rs
@@ -399,7 +399,9 @@ fn div_rem_word(hi: ULimb, lo: ULimb, divisor: ULimb) -> (ULimb, ULimb) {
 
     // LLVM fails to use the div instruction as it is not able to prove
     // that hi < divisor, and therefore the result will fit into 64-bits
-    // SAFETY: Safe since we've validated the parameters.
+    // SAFETY: Safe since we've validated the parameters. This is
+    // never UB, since providing a 0 divisor is valid and just leads
+    // to a division [`error`](https://www.felixcloutier.com/x86/div).
     #[cfg(target_arch = "x86_64")]
     unsafe {
         let mut quot = lo;


### PR DESCRIPTION
This moves to 4 transmutes of strongly-typed PoD with guaranteed layouts and formats, so all can be easily audited.