### PR TITLE
Add major multiplication optimizations.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
       if: ${{ matrix.rust == 'nightly' && matrix.os != 'windows-latest' }}
       run: |
         cargo +nightly fmt -- --check
-        # TODO: re-enable once we complete our API.
-        #cargo +nightly clippy --all-features -- --deny warnings
+        cargo +nightly clippy --all-features -- --deny warnings
 
     - name: Run Quickcheck Tests
       if: ${{ matrix.rust == 'nightly' }}

--- a/devel/Cargo.toml
+++ b/devel/Cargo.toml
@@ -11,12 +11,14 @@ default = ["std"]
 noasm = ["i256/noasm"]
 limb32 = ["i256/limb32"]
 
+[dependencies]
+bnum = { version = "0.12.0", features = ["nightly"] }
+
 [dependencies.i256]
 path = ".."
 default-features = false
 
 [dev-dependencies]
-bnum = { version = "0.12.0", features = ["nightly"] }
 crypto-bigint = "0.5.5"
 criterion = { version = "0.5.0", features = ["html_reports"] }
 fastrand = "2.1.0"

--- a/devel/benches/mul.rs
+++ b/devel/benches/mul.rs
@@ -78,6 +78,32 @@ macro_rules! add_group {
                 ilimb_idata.iter(),
                 bench_op!(wrapping_mul_ilimb, i256::i256, i256::ILimb)
             );
+
+            // overflow handling is especially costly, check this too
+            add_bench!(
+                group,
+                concat!($prefix, "::signed-over-bnum"),
+                bnum_idata.iter(),
+                bench_op!(overflowing_mul, BnumI256)
+            );
+            add_bench!(
+                group,
+                concat!($prefix, "::signed-over-256"),
+                i256_idata.iter(),
+                bench_op!(overflowing_mul, i256::i256)
+            );
+            add_bench!(
+                group,
+                concat!($prefix, "::signed-over-256-ulimb"),
+                ulimb_idata.iter(),
+                bench_op!(overflowing_mul_ulimb, i256::i256, i256::ULimb)
+            );
+            add_bench!(
+                group,
+                concat!($prefix, "::signed-over-256-ilimb"),
+                ilimb_idata.iter(),
+                bench_op!(overflowing_mul_ilimb, i256::i256, i256::ILimb)
+            );
         }
     };
 }

--- a/devel/benches/rotate.rs
+++ b/devel/benches/rotate.rs
@@ -80,8 +80,6 @@ macro_rules! add_group {
                 i256_idata.iter(),
                 bench_op!(rotate_right, i256::i256, u32)
             );
-
-            // TODO: Need signed
         }
     };
 }

--- a/devel/src/lib.rs
+++ b/devel/src/lib.rs
@@ -1,1 +1,35 @@
+// NOTE: We use this for our ASM analysis, which can be done via:
+//      cargo +nightly rustc --release -- --emit asm
 
+#[no_mangle]
+pub const fn mul_signed_bnum(x: bnum::types::I256, y: bnum::types::I256) -> bnum::types::I256 {
+    x.wrapping_mul(y)
+}
+
+#[no_mangle]
+pub const fn mul_unsigned_bnum(x: bnum::types::U256, y: bnum::types::U256) -> bnum::types::U256 {
+    x.wrapping_mul(y)
+}
+
+#[no_mangle]
+pub const fn mul_signed_i256(x: i256::i256, y: i256::i256) -> i256::i256 {
+    x.wrapping_mul(y)
+}
+
+#[no_mangle]
+pub const fn mul_unsigned_i256(x: i256::u256, y: i256::u256) -> i256::u256 {
+    x.wrapping_mul(y)
+}
+
+#[no_mangle]
+pub const fn overflowing_mul_signed_bnum(
+    x: bnum::types::I256,
+    y: bnum::types::I256,
+) -> (bnum::types::I256, bool) {
+    x.overflowing_mul(y)
+}
+
+#[no_mangle]
+pub const fn overflowing_mul_signed_i256(x: i256::u256, y: i256::u256) -> (i256::u256, bool) {
+    x.overflowing_mul(y)
+}

--- a/src/ints/shared_macros.rs
+++ b/src/ints/shared_macros.rs
@@ -1499,7 +1499,7 @@ macro_rules! bigint_define {
         #[must_use]
         pub const fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
             let (a, b) = self.overflowing_add(rhs);
-            let (c, d) = a.overflowing_add(Self::from_u8(carry as u8));
+            let (c, d) = a.overflowing_add_ulimb(carry as $crate::ULimb);
             (c, b | d)
         }
 
@@ -1522,7 +1522,7 @@ macro_rules! bigint_define {
         #[must_use]
         pub const fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {
             let (a, b) = self.overflowing_sub(rhs);
-            let (c, d) = a.overflowing_sub(Self::from_u8(borrow as u8));
+            let (c, d) = a.overflowing_sub_ulimb(borrow as $crate::ULimb);
             (c, b | d)
         }
     };

--- a/src/ints/uint_macros.rs
+++ b/src/ints/uint_macros.rs
@@ -242,9 +242,9 @@ macro_rules! uint_ops_define {
         #[inline]
         pub fn div_ceil(self, rhs: Self) -> Self {
             let (d, r) = self.wrapping_div_rem(rhs);
-            if r.gt_const(Self::from_u8(0)) {
+            if !r.eq_const(Self::from_u8(0)) {
                 // NOTE: This can't overflow
-                d.wrapping_add(Self::from_u8(1))
+                d.wrapping_add_ulimb(1)
             } else {
                 d
             }

--- a/src/math/div.rs
+++ b/src/math/div.rs
@@ -464,7 +464,7 @@ const fn full_shl<const N: usize>(v: &[ULimb; N], shift: u32) -> ArrayPlusOne<N>
     out[0] = v[0] << shift;
     let mut i = 1;
     while i < N {
-        out[i] = v[i - 1] >> (ULimb::BITS - shift) | v[i] << shift;
+        out[i] = (v[i - 1] >> (ULimb::BITS - shift)) | (v[i] << shift);
         i += 1;
     }
     let carry = v[N - 1] >> (ULimb::BITS - shift);
@@ -481,7 +481,7 @@ const fn full_shr<const N: usize>(a: &ArrayPlusOne<N>, shift: u32) -> [ULimb; N]
     let mut out = [0; N];
     let mut i = 0;
     while i < N - 1 {
-        out[i] = a.0[i] >> shift | a.0[i + 1] << (ULimb::BITS - shift);
+        out[i] = (a.0[i] >> shift) | (a.0[i + 1] << (ULimb::BITS - shift));
         i += 1;
     }
     out[N - 1] = a.0[N - 1] >> shift;


### PR DESCRIPTION
This fixes all the multiplication regressions we had from before, by just skipping the hopes our compiler would see through the wrapping signed mul abstraction and would just use the raw unsigned variant.