### PR TITLE
Fully generalize our rol/ror/shl/shr logic.

### DIFF
--- a/devel/tests/native_math.rs
+++ b/devel/tests/native_math.rs
@@ -1,8 +1,6 @@
 use i256::math::*;
 use quickcheck::quickcheck;
 
-const LO32: u64 = u32::MAX as u64;
-
 const fn split(x: u64) -> (u32, u32) {
     (x as u32, (x >> 32) as u32)
 }
@@ -12,8 +10,6 @@ const fn unsplit(x0: u32, x1: u32) -> u64 {
 }
 
 quickcheck! {
-    // FIXME: Add all our wrapping, checked, etc. variants here too...
-
     fn wrapping_add_u32_quickcheck(x: u64, y: u64) -> bool {
         let (x0, x1) = split(x);
         let (y0, y1) = split(y);
@@ -95,8 +91,8 @@ quickcheck! {
         let (x0, x1) = split(x);
         let n = (n % 64) as u32;
         let expected = x << n;
-        let (lo, hi) = shl_u32(x0, x1, n);
-        let actual = unsplit(lo, hi);
+        let result = shl_u32([x0, x1], n);
+        let actual = unsplit(result[0], result[1]);
         expected == actual
     }
 
@@ -104,24 +100,24 @@ quickcheck! {
         let (x0, x1) = split(x);
         let n = (n % 64) as u32;
         let expected = x >> n;
-        let (lo, hi) = shr_u32(x0, x1, n);
-        let actual = unsplit(lo, hi);
+        let result = shr_u32([x0, x1], n);
+        let actual = unsplit(result[0], result[1]);
         expected == actual
     }
 
     fn rotate_left_u32_quickcheck(x: u64, n: u32) -> bool {
         let (x0, x1) = split(x);
         let expected = x.rotate_left(n);
-        let (lo, hi) = rotate_left_u32(x0, x1, n);
-        let actual = unsplit(lo, hi);
+        let result = rotate_left_u32([x0, x1], n);
+        let actual = unsplit(result[0], result[1]);
         expected == actual
     }
 
     fn rotate_right_u32_quickcheck(x: u64, n: u32) -> bool {
         let (x0, x1) = split(x);
         let expected = x.rotate_right(n);
-        let (lo, hi) = rotate_right_u32(x0, x1, n);
-        let actual = unsplit(lo, hi);
+        let result = rotate_right_u32([x0, x1], n);
+        let actual = unsplit(result[0], result[1]);
         expected == actual
     }
 
@@ -276,40 +272,20 @@ quickcheck! {
     }
 
     fn shl_i32_quickcheck(x: i64, n: u32) -> bool {
-        let x0 = ((x as u64) & LO32) as u32;
-        let x1 = ((x as u64) >> 32) as i32;
+        let (x0, x1) = split(x as u64);
         let n = (n % 64) as u32;
         let expected = x << n;
-        let (lo, hi) = shl_i32(x0, x1, n);
-        let actual = lo as i64 + ((hi as u64) << 32) as i64;
-        expected == actual
-    }
-
-    fn shr_i32_quickcheck(x: i64, n: u32) -> bool {
-        let x0 = ((x as u64) & LO32) as u32;
-        let x1 = ((x as u64) >> 32) as i32;
-        let n = (n % 64) as u32;
-        let expected = x >> n;
-        let (lo, hi) = shr_i32(x0, x1, n);
-        let actual = lo as i64 + ((hi as u64) << 32) as i64;
-        expected == actual
-    }
-
-    fn rotate_left_i32_quickcheck(x: i64, n: u32) -> bool {
-        let x0 = ((x as u64) & LO32) as u32;
-        let x1 = ((x as u64) >> 32) as i32;
-        let expected = x.rotate_left(n);
-        let (lo, hi) = rotate_left_i32(x0, x1, n);
-        let actual = unsplit(lo, hi as u32);
+        let result = shl_i32([x0, x1], n);
+        let actual = unsplit(result[0], result[1]);
         expected == actual as i64
     }
 
-    fn rotate_right_i32_quickcheck(x: i64, n: u32) -> bool {
-        let x0 = ((x as u64) & LO32) as u32;
-        let x1 = ((x as u64) >> 32) as i32;
-        let expected = x.rotate_right(n);
-        let (lo, hi) = rotate_right_i32(x0, x1, n);
-        let actual = unsplit(lo, hi as u32);
+    fn shr_i32_quickcheck(x: i64, n: u32) -> bool {
+        let (x0, x1) = split(x as u64);
+        let n = (n % 64) as u32;
+        let expected = x >> n;
+        let result = shr_i32([x0, x1], n);
+        let actual = unsplit(result[0], result[1]);
         expected == actual as i64
     }
 }

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -724,8 +724,8 @@ fn overflowing_sub_tests() {
     // back to the correct value: the end value is what it should be.
     let (z, o) = x.overflowing_sub(y);
     assert!(!o, "should not have overflowed");
-    assert_eq!(z.high(), i128::MAX);
-    assert_eq!(z.low(), u128::MAX);
+    assert_eq!(z.get_wide(1), i128::MAX as u128);
+    assert_eq!(z.get_wide(0), u128::MAX);
 
     assert!(x.checked_sub(y).is_some());
 }
@@ -734,54 +734,54 @@ fn overflowing_sub_tests() {
 fn wrapping_neg_tests() {
     let x = i256::i256::from_le_u64([0, 0, 0, 0]);
     let neg = x.wrapping_neg();
-    assert_eq!(neg.low(), 0);
-    assert_eq!(neg.high(), 0);
+    assert_eq!(neg.get_wide(0), 0);
+    assert_eq!(neg.get_wide(1), 0);
 }
 
 #[test]
 fn saturating_neg_tests() {
     let x = i256::i256::from_le_u64([0, 0, 0, 0]);
     let neg = x.saturating_neg();
-    assert_eq!(neg.low(), 0);
-    assert_eq!(neg.high(), 0);
+    assert_eq!(neg.get_wide(0), 0);
+    assert_eq!(neg.get_wide(1), 0);
 
     // 0, -1
     let x = i256::i256::from_le_u64([0, 0, u64::MAX, u64::MAX]);
     let neg = x.saturating_neg();
-    assert_eq!(neg.low(), 0);
-    assert_eq!(neg.high(), 1);
+    assert_eq!(neg.get_wide(0), 0);
+    assert_eq!(neg.get_wide(1), 1);
 
     let neg = x.checked_neg();
     assert!(neg.is_some());
     let neg = neg.unwrap();
-    assert_eq!(neg.low(), 0);
-    assert_eq!(neg.high(), 1);
+    assert_eq!(neg.get_wide(0), 0);
+    assert_eq!(neg.get_wide(1), 1);
 }
 
 #[test]
 fn saturating_abs_tests() {
     let x = i256::i256::from_le_u64([0, 0, 0, 0]);
     let abs = x.saturating_abs();
-    assert_eq!(abs.low(), 0);
-    assert_eq!(abs.high(), 0);
+    assert_eq!(abs.get_wide(0), 0);
+    assert_eq!(abs.get_wide(1), 0);
 
     let x = i256::i256::from_le_u64([0, 0, u64::MAX, u64::MAX]);
     let abs = x.saturating_abs();
-    assert_eq!(abs.low(), 0);
-    assert_eq!(abs.high(), 1);
+    assert_eq!(abs.get_wide(0), 0);
+    assert_eq!(abs.get_wide(1), 1);
 
     let x = util::to_i256(u128::MAX, u128::MAX as i128);
     let abs = x.saturating_abs();
-    assert_eq!(abs.low(), 1);
-    assert_eq!(abs.high(), 0);
+    assert_eq!(abs.get_wide(0), 1);
+    assert_eq!(abs.get_wide(1), 0);
 }
 
 #[test]
 fn abs_tests() {
     let x = i256::i256::from_le_u64([0, 0, 0, 0]);
     let abs = x.abs();
-    assert_eq!(abs.low(), 0);
-    assert_eq!(abs.high(), 0);
+    assert_eq!(abs.get_wide(0), 0);
+    assert_eq!(abs.get_wide(1), 0);
 
     let x = util::to_i256(0, i128::MIN);
     assert!(x.checked_abs().is_none());
@@ -789,8 +789,8 @@ fn abs_tests() {
     let x = util::to_i256(u128::MAX, u128::MAX as i128);
     assert!(x.checked_abs().is_some());
     let abs = x.checked_abs().unwrap();
-    assert_eq!(abs.low(), 1);
-    assert_eq!(abs.high(), 0);
+    assert_eq!(abs.get_wide(0), 1);
+    assert_eq!(abs.get_wide(1), 0);
 }
 
 #[test]

--- a/src/ints/i256.rs
+++ b/src/ints/i256.rs
@@ -41,67 +41,6 @@ impl i256 {
         kind => signed,
         short_circuit => false,
     );
-
-    /// Shifts the bits to the left by a specified amount, `n`,
-    /// wrapping the truncated bits to the end of the resulting integer.
-    ///
-    /// Please note this isn't the same operation as the `<<` shifting operator!
-    ///
-    /// See [`i128::rotate_left`].
-    #[inline(always)]
-    pub const fn rotate_left(self, n: u32) -> Self {
-        let (lo, hi) = math::rotate_left_i128(self.low(), self.high(), n);
-        Self::new(lo, hi)
-    }
-
-    /// Shifts the bits to the right by a specified amount, `n`,
-    /// wrapping the truncated bits to the beginning of the resulting
-    /// integer.
-    ///
-    /// Please note this isn't the same operation as the `>>` shifting operator!
-    ///
-    /// See [`i128::rotate_right`].
-    #[inline(always)]
-    pub const fn rotate_right(self, n: u32) -> Self {
-        let (lo, hi) = math::rotate_right_i128(self.low(), self.high(), n);
-        Self::new(lo, hi)
-    }
-
-    /// Panic-free bitwise shift-left; yields `self << mask(rhs)`, where `mask`
-    /// removes any high-order bits of `rhs` that would cause the shift to
-    /// exceed the bitwidth of the type.
-    ///
-    /// Note that this is *not* the same as a rotate-left; the RHS of a wrapping
-    /// shift-left is restricted to the range of the type, rather than the
-    /// bits shifted out of the LHS being returned to the other end.
-    /// The primitive integer types all implement a
-    /// [`rotate_left`](Self::rotate_left) function, which may be what you
-    /// want instead.
-    ///
-    /// See [`i128::wrapping_shl`].
-    #[inline(always)]
-    pub const fn wrapping_shl(self, rhs: u32) -> Self {
-        let (lo, hi) = math::shl_i128(self.low(), self.high(), rhs % Self::BITS);
-        Self::new(lo, hi)
-    }
-
-    /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`, where `mask`
-    /// removes any high-order bits of `rhs` that would cause the shift to
-    /// exceed the bitwidth of the type.
-    ///
-    /// Note that this is *not* the same as a rotate-right; the RHS of a
-    /// wrapping shift-right is restricted to the range of the type, rather
-    /// than the bits shifted out of the LHS being returned to the other
-    /// end. The primitive integer types all implement a
-    /// [`rotate_right`](Self::rotate_right) function, which may be what you
-    /// want instead.
-    ///
-    /// See [`i128::wrapping_shr`].
-    #[inline(always)]
-    pub const fn wrapping_shr(self, rhs: u32) -> Self {
-        let (lo, hi) = math::shr_i128(self.low(), self.high(), rhs % Self::BITS);
-        Self::new(lo, hi)
-    }
 }
 
 int_traits_define!(type => i256, unsigned_type => u256);

--- a/src/ints/u256.rs
+++ b/src/ints/u256.rs
@@ -36,67 +36,6 @@ impl u256 {
         kind => unsigned,
         short_circuit => false,
     );
-
-    /// Shifts the bits to the left by a specified amount, `n`,
-    /// wrapping the truncated bits to the end of the resulting integer.
-    ///
-    /// Please note this isn't the same operation as the `<<` shifting operator!
-    ///
-    /// See [`u128::rotate_left`].
-    #[inline(always)]
-    pub const fn rotate_left(self, n: u32) -> Self {
-        let (lo, hi) = math::rotate_left_u128(self.low(), self.high(), n);
-        Self::new(lo, hi)
-    }
-
-    /// Shifts the bits to the right by a specified amount, `n`,
-    /// wrapping the truncated bits to the beginning of the resulting
-    /// integer.
-    ///
-    /// Please note this isn't the same operation as the `>>` shifting operator!
-    ///
-    /// See [`u128::rotate_right`].
-    #[inline(always)]
-    pub const fn rotate_right(self, n: u32) -> Self {
-        let (lo, hi) = math::rotate_right_u128(self.low(), self.high(), n);
-        Self::new(lo, hi)
-    }
-
-    /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
-    /// where `mask` removes any high-order bits of `rhs` that
-    /// would cause the shift to exceed the bitwidth of the type.
-    ///
-    /// Note that this is *not* the same as a rotate-left; the
-    /// RHS of a wrapping shift-left is restricted to the range
-    /// of the type, rather than the bits shifted out of the LHS
-    /// being returned to the other end. The primitive integer
-    /// types all implement a [`rotate_left`](Self::rotate_left) function,
-    /// which may be what you want instead.
-    ///
-    /// See [`u128::wrapping_shl`].
-    #[inline(always)]
-    pub const fn wrapping_shl(self, rhs: u32) -> Self {
-        let (lo, hi) = math::shl_u128(self.low(), self.high(), rhs % Self::BITS);
-        Self::new(lo, hi)
-    }
-
-    /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`,
-    /// where `mask` removes any high-order bits of `rhs` that
-    /// would cause the shift to exceed the bitwidth of the type.
-    ///
-    /// Note that this is *not* the same as a rotate-right; the
-    /// RHS of a wrapping shift-right is restricted to the range
-    /// of the type, rather than the bits shifted out of the LHS
-    /// being returned to the other end. The primitive integer
-    /// types all implement a [`rotate_right`](Self::rotate_right) function,
-    /// which may be what you want instead.
-    ///
-    /// See [`u128::wrapping_shr`].
-    #[inline(always)]
-    pub const fn wrapping_shr(self, rhs: u32) -> Self {
-        let (lo, hi) = math::shr_u128(self.low(), self.high(), rhs % Self::BITS);
-        Self::new(lo, hi)
-    }
 }
 
 uint_traits_define!(type => u256, signed_type => i256);

--- a/src/ints/uint_macros.rs
+++ b/src/ints/uint_macros.rs
@@ -4,25 +4,6 @@
 //! implementing your own produces many errors, look through
 //! and custom implement the types required.
 
-/// Define the high and low implementations for 4 limb implementations.
-///
-/// This is specific for **ONLY** our 256-bit integers (4x 64-bit limbs).
-macro_rules! uint_high_low_define {
-    (
-        self => $t:ty,
-        low_type => $lo_t:ty,
-        high_type => $hi_t:ty,
-        kind => $kind:ident $(,)?
-    ) => {
-        high_low_define!(
-            self => $t,
-            low_type => $lo_t,
-            high_type => $hi_t,
-            kind => $kind,
-        );
-    };
-}
-
 #[rustfmt::skip]
 macro_rules! uint_associated_consts_define {
     (
@@ -81,6 +62,87 @@ macro_rules! uint_cmp_define {
 macro_rules! uint_bitops_define {
     (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
         bitops_define!(type => $s_t, wide_type => $wide_t);
+
+        /// Shifts the bits to the left by a specified amount, `n`,
+        /// wrapping the truncated bits to the end of the resulting integer.
+        ///
+        /// Please note this isn't the same operation as the `<<` shifting operator!
+        ///
+        #[doc = concat!("See [`", stringify!($wide_t), "::rotate_left`].")]
+        #[inline(always)]
+        pub const fn rotate_left(self, n: u32) -> Self {
+            #[cfg(not(feature = "limb32"))]
+            let result = math::rotate_left_u128(self.to_ne_wide(), n);
+
+            #[cfg(feature = "limb32")]
+            let result = math::rotate_left_u64(self.to_ne_wide(), n);
+
+            Self::from_ne_wide(result)
+        }
+
+        /// Shifts the bits to the right by a specified amount, `n`,
+        /// wrapping the truncated bits to the beginning of the resulting
+        /// integer.
+        ///
+        /// Please note this isn't the same operation as the `>>` shifting operator!
+        ///
+        #[doc = concat!("See [`", stringify!($wide_t), "::rotate_right`].")]
+        #[inline(always)]
+        pub const fn rotate_right(self, n: u32) -> Self {
+            #[cfg(not(feature = "limb32"))]
+            let result = math::rotate_right_u128(self.to_ne_wide(), n);
+
+            #[cfg(feature = "limb32")]
+            let result = math::rotate_right_u64(self.to_ne_wide(), n);
+
+            Self::from_ne_wide(result)
+        }
+
+        /// Panic-free bitwise shift-left; yields `self << mask(rhs)`,
+        /// where `mask` removes any high-order bits of `rhs` that
+        /// would cause the shift to exceed the bitwidth of the type.
+        ///
+        /// Note that this is *not* the same as a rotate-left; the
+        /// RHS of a wrapping shift-left is restricted to the range
+        /// of the type, rather than the bits shifted out of the LHS
+        /// being returned to the other end. The primitive integer
+        /// types all implement a [`rotate_left`](Self::rotate_left) function,
+        /// which may be what you want instead.
+        ///
+        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_shl`].")]
+        #[inline(always)]
+        pub const fn wrapping_shl(self, rhs: u32) -> Self {
+            #[cfg(not(feature = "limb32"))]
+            let result = math::shl_u128(self.to_ne_wide(), rhs % Self::BITS);
+
+            #[cfg(feature = "limb32")]
+            let result = math::shl_u64(self.to_ne_wide(), rhs % Self::BITS);
+
+            Self::from_ne_wide(result)
+        }
+
+        /// Panic-free bitwise shift-right; yields `self >> mask(rhs)`,
+        /// where `mask` removes any high-order bits of `rhs` that
+        /// would cause the shift to exceed the bitwidth of the type.
+        ///
+        /// Note that this is *not* the same as a rotate-right; the
+        /// RHS of a wrapping shift-right is restricted to the range
+        /// of the type, rather than the bits shifted out of the LHS
+        /// being returned to the other end. The primitive integer
+        /// types all implement a [`rotate_right`](Self::rotate_right) function,
+        /// which may be what you want instead.
+        ///
+        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_shr`].")]
+        #[inline(always)]
+        pub const fn wrapping_shr(self, rhs: u32) -> Self {
+            #[cfg(not(feature = "limb32"))]
+            let result = math::shr_u128(self.to_ne_wide(), rhs % Self::BITS);
+
+            #[cfg(feature = "limb32")]
+            let result = math::shr_u64(self.to_ne_wide(), rhs % Self::BITS);
+
+            Self::from_ne_wide(result)
+        }
     };
 }
 
@@ -1719,12 +1781,6 @@ macro_rules! uint_impl_define {
         );
         uint_bitops_define!(signed_type => $s_t, wide_type => $wide_u_t);
         uint_byte_order_define!(signed_type => $s_t, wide_type => $wide_u_t);
-        uint_high_low_define!(
-            self => $self,
-            low_type => $wide_u_t,
-            high_type => $wide_u_t,
-            kind => $kind,
-        );
         uint_cmp_define!(
             low_type => $wide_u_t,
             high_type => $wide_u_t,


### PR DESCRIPTION
This keeps optimizations for cases when there's only 2 elements.