### PR TITLE
Make larger type sizes conditionally enabled.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Move `I384`, etc. under the `i384`, `i512`, and `i1024` features.
+
 ## [0.1.12] 2024-12-30
 
 ## Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,12 @@ exclude = [
 [features]
 default = ["std"]
 std = []
+i384 = []
+# Enable the `U384` and `I384` types.
+i512 = []
+# Enable the `U512` and `I512` types.
+i1024 = []
+# Enable the `U1024` and `I1024` types.
 
 # Internal only features.
 # Enable the lint checks.
@@ -51,3 +57,7 @@ opt-level = 3
 debug = false
 debug-assertions = false
 lto = true
+
+[package.metadata.docs.rs]
+features = ["i384", "i512", "i1024"]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -1,31 +1,45 @@
+
 # i256
 
 Optimized implementations of 256-bit signed and unsigned integers.
 
 This contains a fixed-width, performant implementation for 256-bit signed and unsigned integers. This has significantly faster performance for basic math operations than comparable fixed-width integer types, since it can use optimizations from 128-bit integers on 64-bit architectures.
 
+## Design
+
+This contains variable-time, optimized algorithms for smaller big integers, primarily, 256-bit integers. It supports a no_std environment, requiring no allocation with all integers stored on the stack.
+
+## Features
+
+This crate is optimized for small variants of big integers, but a few additional types can be enabled via the following features:
+
+- `i384`: Add the 384-bit I384 and U384 types.
+- `i512`: Add the 512-bit I512 and U512 types.
+- `i1024`: Add the 1024-bit I1024 and U1024 types.
+
+If you need larger integers, [`crypto-bigint`] has high-performance addition, subtraction, and multiplication. With integers with a large number of bits, it uses Karatsuba multiplication, which is significantly asymptotically faster.
+
 ## Use Case
 
-`i256` is for a very specific purpose: relatively high-performance, fixed-sized 256-bit integers. This is dependent on support for native 64-bit integer multiplies on the architecture, and highly benefits from 64-bit to 128-bit widening multiplies (supported on `x86_64`). For example, on `x86_64`, we can get 256-bit multiplications in at worst 10 multiplies and 15 adds, and significantly faster in most cases. Likewise, 256-bit addition/subtraction is in 6 adds/subtracts, significantly more efficient than building from smaller type sizes.
+[`i256`] is for a very specific purpose: relatively high-performance, fixed-sized 256-bit integers. This is dependent on support for native 64-bit integer multiplies on the architecture, and highly benefits from 64-bit to 128-bit widening multiplies (supported on `x86_64`). For example, on `x86_64`, we can get 256-bit multiplications in at worst 10 multiplies and 15 adds, and significantly faster in most cases. However, using 256-bit x 64-bit multiplication, we can get a worst case scenario in 5 `mul`, 3 `add`, and 6 `sub` instructions.
 
-This will, for obvious reasons, not support larger type sizes. 512+ bit integers require types comprised of an array of limbs, sacrificing performance for this specific use-case in their design. If you need anything else, you probably want one of the following libraries:
-- [bnum](https://crates.io/crates/bnum): Arbitrary-precision, fixed-width, big integer support.
-- [crypto-bigint](https://crates.io/crates/crypto-bigint): Constant-time, arbitrary-precision, fixed-width, big integer support suitable for cryptographically secure applications.
-- [num-bigint](https://crates.io/crates/num-bigint), [malachite](https://crates.io/crates/malachite), or [rug](https://crates.io/crates/rug): Dynamic-width big integers with high-performance calculations with very large integers.
+This will, for obvious reasons, not support significantly larger type sizes. It is optimized only for a smaller number of bits.
 
-Specifically, `i256` has optimizations that would be considered anti-features for these libraries: better performance for smaller values, and operations with native, scalar values. This is particularly useful when doing incremental operations with native integers.
+- [`bnum`]: Arbitrary-precision, fixed-width, big integer support.
+- [`crypto-bigint`]: Constant-time, arbitrary-precision, fixed-width, big integer support suitable for cryptographically secure applications.
+- [`num-bigint`], [`malachite`], or [`rug`]: Dynamic-width big integers with high-performance calculations with very large integers.
+
+Specifically, [`i256`] has optimizations that would be considered anti-features for these libraries: better performance for smaller values (variable-time calculations) and operations with native, scalar values. This is particularly useful when doing incremental operations with [native integers][`u64`], with performance improvements greater than 2 fold in many cases,
 
 ## Versioning and Version Support
 
 **Rustc Compatibility**
 
-- `i256` currently supports 1.59+, including stable, beta, and nightly. This aims to support at least the Rust included in the latest stable Debian release.
-
-Please report any errors compiling a supported `i256` version on a compatible Rustc version.
+[`i256`] currently supports 1.59+, including stable, beta, and nightly. This aims to support at least the Rust included in the latest stable Debian release. Please report any errors compiling a supported [`i256`] version on a compatible Rustc version.
 
 **Versioning**
 
-`i256` uses [semantic versioning](https://semver.org/). Removing support for Rustc versions newer than the latest stable Debian or Ubuntu version is considered an incompatible API change, requiring a major (minor pre-1.0) version change.
+[`i256`] uses [semantic versioning](https://semver.org/). Removing support for Rustc versions newer than the latest stable Debian or Ubuntu version is considered an incompatible API change, requiring a major (minor pre-1.0) version change.
 
 ## Changelog
 
@@ -33,7 +47,7 @@ All changes are documented in [CHANGELOG](https://github.com/Alexhuszagh/i256/bl
 
 ## License
 
-`i256` is dual licensed under the Apache 2.0 license as well as the MIT license.
+[`i256`] is dual licensed under the Apache 2.0 license as well as the MIT license.
 
 Almost all of the accessory methods in [ints](/src/ints/), such as the `checked_*`, `unchecked_*`, `strict_*`, and others, including their documentation, are taken directly from the Rust implementation, specifically, [`uint_macros`] and [`int_macros`]. The core algorithms under [math](/src/math/) for numeric operations, both their wrapping and overflowing forms, are not.
 
@@ -43,3 +57,11 @@ Almost all of the accessory methods in [ints](/src/ints/), such as the `checked_
 ## Contributing
 
 Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in i256 by you, as defined in the Apache-2.0 license, shall be dual licensed as above, without any additional terms or conditions. Contributing to the repository means abiding by the [code of conduct](https://github.com/Alexhuszagh/i256/blob/main/CODE_OF_CONDUCT.md).
+
+[`crypto-bigint`]: https://crates.io/crates/crypto-bigint
+[`bnum`]: https://crates.io/crates/bnum
+[`num-bigint`]: https://crates.io/crates/num-bigint
+[`malachite`]: https://crates.io/crates/malachite
+[`rug`]: https://crates.io/crates/rug
+[`u64`]: https://doc.rust-lang.org/std/primitive.u64.html
+[`i256`]: https://crates.io/crates/i256

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,4 +1,4 @@
-avoid-breaking-exported-api = false
+avoid-breaking-exported-api = true
 disallowed-macros = [
     # Can also use an inline table with a `path` key.
     { path = "std::print", reason = "no IO allowed" },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,66 @@
 //! for basic math operations than comparable fixed-width integer types,
 //! since it can use optimizations from 128-bit integers on 64-bit
 //! architectures.
+//!
+//! ## Design
+//!
+//! This contains variable-time, optimized algorithms for smaller big integers,
+//! primarily, 256-bit integers. It supports a `no_std` environment, requiring
+//! no allocation with all integers stored on the stack.
+//!
+//! ## Features
+//!
+//! This crate is optimized for small variants of big integers, but a few
+//! additional types can be enabled via the following features:
+#![cfg_attr(feature = "i384", doc = "- `i384`: Add the 384-bit [`I384`] and [`U384`] types.")]
+#![cfg_attr(not(feature = "i384"), doc = "- `i384`: Add the 384-bit `I384` and `U384` types.")]
+#![cfg_attr(feature = "i512", doc = "- `i512`: Add the 512-bit [`I512`] and [`U512`] types.")]
+#![cfg_attr(not(feature = "i512"), doc = "- `i512`: Add the 512-bit `I512` and `U512` types.")]
+#![cfg_attr(feature = "i1024", doc = "- `i1024`: Add the 1024-bit [`I1024`] and [`U1024`] types.")]
+#![cfg_attr(not(feature = "i1024"), doc = "- `i1024`: Add the 1024-bit `I1024` and `U1024` types.")]
+//!
+//! If you need larger integers, [`crypto-bigint`] has high-performance
+//! addition, subtraction, and multiplication. With integers with a large
+//! number of bits, it uses Karatsuba multiplication, which is significantly
+//! asymptotically faster.
+//!
+//! ## Use Case
+//!
+//! [`i256`] is for a very specific purpose: relatively high-performance,
+//! fixed-sized 256-bit integers. This is dependent on support for native 64-bit
+//! integer multiplies on the architecture, and highly benefits from 64-bit to
+//! 128-bit widening multiplies (supported on `x86_64`). For example, on
+//! `x86_64`, we can get 256-bit multiplications in at worst 10 multiplies and
+//! 15 adds, and significantly faster in most cases. However, using 256-bit x
+//! 64-bit multiplication, we can get a worst case scenario in 5 `mul`, 3 `add`,
+//! and 6 `sub` instructions, with 2x+ better performance on both `x86_64` and
+//! `aarch64`.
+//!
+//! This will, for obvious reasons, not support significantly larger type sizes.
+//! It is optimized only for a smaller number of bits.
+//!
+//! - [`bnum`]: Arbitrary-precision, fixed-width, big integer support.
+//! - [`crypto-bigint`]: Constant-time, arbitrary-precision, fixed-width, big
+//!   integer support
+//! suitable for cryptographically secure applications.
+//! - [`num-bigint`], [`malachite`], or [`rug`]: Dynamic-width big integers with
+//!   high-
+//! performance calculations with very large integers.
+
+//! Specifically, [`i256`] has optimizations that would be considered
+//! anti-features for these libraries: better performance for smaller values
+//! (variable-time calculations) and operations with native, scalar values. This
+//! is particularly useful when doing incremental operations with [native
+//! integers][`u64`], with performance improvements greater than 2 fold in many
+//! cases,
+//!
+//! [`crypto-bigint`]: https://crates.io/crates/crypto-bigint
+//! [`bnum`]: https://crates.io/crates/bnum
+//! [`num-bigint`]: https://crates.io/crates/num-bigint
+//! [`malachite`]: https://crates.io/crates/malachite
+//! [`rug`]: https://crates.io/crates/rug
+//! [`u64`]: https://doc.rust-lang.org/std/primitive.u64.html
+//! [`i256`]: https://crates.io/crates/i256
 
 #![allow(unused_unsafe)]
 #![cfg_attr(feature = "lint", warn(unsafe_op_in_unsafe_fn))]
@@ -90,6 +150,7 @@ define!(
     signed_wide => i128,
     bits => 256,
 );
+#[cfg(feature = "i384")]
 define!(
     unsigned => U384,
     signed => I384,
@@ -97,6 +158,7 @@ define!(
     signed_wide => i128,
     bits => 384,
 );
+#[cfg(feature = "i512")]
 define!(
     unsigned => U512,
     signed => I512,
@@ -104,6 +166,7 @@ define!(
     signed_wide => i128,
     bits => 512,
 );
+#[cfg(feature = "i1024")]
 define!(
     unsigned => U1024,
     signed => I1024,


### PR DESCRIPTION
By making each a separate feature, this minimizes compile time, reducing build times by ~2 fold for common cases.

Closes #62.