### PR TITLE
Refactor to simplify our docstrings.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
 - Move `I384`, etc. under the `i384`, `i512`, and `i1024` features.
+- Added many `#[must_use]` attributes for expensive operations which create copies of values.
 
 ## [0.1.12] 2024-12-30
 

--- a/src/int/bitops.rs
+++ b/src/int/bitops.rs
@@ -7,6 +7,7 @@ macro_rules! define {
 
         #[inline(always)]
         #[doc = $crate::shared::bitops::wrapping_shl_doc!($wide_t)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             let result = $crate::math::shift::left_iwide(self.to_ne_wide(), rhs % Self::BITS);
             Self::from_ne_wide(result)
@@ -14,6 +15,7 @@ macro_rules! define {
 
         #[inline(always)]
         #[doc = $crate::shared::bitops::wrapping_shr_doc!($wide_t)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shr(self, rhs: u32) -> Self {
             let result = $crate::math::shift::right_iwide(self.to_ne_wide(), rhs % Self::BITS);
             Self::from_ne_wide(result)

--- a/src/int/casts.rs
+++ b/src/int/casts.rs
@@ -21,7 +21,7 @@ macro_rules! define {
         /// This produces the same result as an `as` cast, but ensures that the
         /// bit-width remains the same.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::cast_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, cast_unsigned)]
         #[inline(always)]
         pub const fn cast_unsigned(self) -> $u_t {
             self.as_unsigned()

--- a/src/int/checked.rs
+++ b/src/int/checked.rs
@@ -8,8 +8,9 @@ macro_rules! define {
         /// Checked addition with an unsigned integer. Computes `self + rhs`,
         /// returning `None` if overflow occurred.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_add_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_add_unsigned)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_unsigned(self, rhs: $u_t) -> Option<Self> {
             let (value, overflowed) = self.overflowing_add_unsigned(rhs);
             if !overflowed {
@@ -22,8 +23,9 @@ macro_rules! define {
         /// Checked subtraction with an unsigned integer. Computes `self - rhs`,
         /// returning `None` if overflow occurred.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_sub_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_sub_unsigned)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_unsigned(self, rhs: $u_t) -> Option<Self> {
             let (value, overflowed) = self.overflowing_sub_unsigned(rhs);
             if !overflowed {
@@ -35,8 +37,9 @@ macro_rules! define {
 
         /// Checked negation. Computes `-self`, returning `None` if `self == MIN`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_neg`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_neg)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_neg(self) -> Option<Self> {
             let (value, overflowed) = self.overflowing_neg();
             if !overflowed {
@@ -49,8 +52,9 @@ macro_rules! define {
         /// Checked absolute value. Computes `self.abs()`, returning `None` if
         /// `self == MIN`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_abs`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_abs)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_abs(self) -> Option<Self> {
             match self.overflowing_abs() {
                 (value, false) => Some(value),
@@ -68,8 +72,9 @@ macro_rules! define {
         /// `checked_ilog2` can produce results more efficiently for base 2, and
         /// `checked_ilog10` can produce results more efficiently for base 10.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_ilog`].")]
-        #[inline]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_ilog)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_ilog(self, base: Self) -> Option<u32> {
             match self.le_const(Self::from_u8(0)) || base.le_const(Self::from_u8(1)) {
                 true => None,
@@ -104,8 +109,9 @@ macro_rules! define {
         /// multiple of `rhs`. Returns `None` if `rhs` is zero or the operation
         /// would result in overflow.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_next_multiple_of`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_next_multiple_of)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
             // This would otherwise fail when calculating `r` when self == T::MIN.
             if rhs.eq_const(Self::from_i8(-1)) {

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -6,8 +6,9 @@ macro_rules! define {
 
         /// Add a signed limb to the big integer.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_ilimb(self, n: $crate::ILimb) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_add_ilimb(n)
@@ -21,8 +22,9 @@ macro_rules! define {
 
         /// Subtract a signed limb from the big integer.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_ilimb(self, n: $crate::ILimb) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_sub_ilimb(n)
@@ -36,8 +38,9 @@ macro_rules! define {
 
         /// Multiply our big integer by a signed limb.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_ilimb(self, n: $crate::ILimb) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_mul_ilimb(n)
@@ -52,8 +55,9 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by a signed limb.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_ilimb(self, n: $crate::ILimb) -> (Self, $crate::ILimb) {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_div_rem_ilimb(n)
@@ -67,16 +71,18 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by a signed limb.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_ilimb(self, n: $crate::ILimb) -> Self {
             self.div_rem_ilimb(n).0
         }
 
         /// Get the remainder of our big integer divided by a signed limb.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_ilimb(self, n: $crate::ILimb) -> $crate::ILimb {
             self.div_rem_ilimb(n).1
         }
@@ -87,8 +93,9 @@ macro_rules! define {
 
         /// Add an unsigned limb to the big integer, wrapping on overflow.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_ulimb(self, n: $crate::ULimb) -> Self {
             let limbs = $crate::math::add::wrapping_ulimb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -96,8 +103,9 @@ macro_rules! define {
 
         /// Add a signed limb to the big integer, wrapping on overflow.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_ilimb(self, n: $crate::ILimb) -> Self {
             let limbs = $crate::math::add::wrapping_ilimb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -106,8 +114,9 @@ macro_rules! define {
         /// Subtract an unsigned limb from the big integer, wrapping on
         /// overflow.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_ulimb(self, n: $crate::ULimb) -> Self {
             let limbs = $crate::math::sub::wrapping_ulimb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -116,8 +125,9 @@ macro_rules! define {
         /// Subtract a signed limb from the big integer, wrapping on
         /// overflow.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_ilimb(self, n: $crate::ILimb) -> Self {
             let limbs = $crate::math::sub::wrapping_ilimb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -125,13 +135,14 @@ macro_rules! define {
 
         /// Multiply our big integer by an unsigned limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         /// This in worst case 5 `mul`, 3 `add`, and 6 `sub` instructions,
         /// because of branching in nearly every case, it has better
         /// performance and optimizes nicely for small multiplications.
         /// See [`u256::wrapping_mul_ulimb`] for a more detailed analysis,
         /// which is identical.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_ulimb(self, n: $crate::ULimb) -> Self {
             let limbs = $crate::math::mul::wrapping_ulimb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -139,11 +150,12 @@ macro_rules! define {
 
         /// Multiply our big integer by a signed limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         /// This in worst case 4 `mul`, 3 `add`, and 6 `sub` instructions,
         /// because of branching in nearly every case, it has better
         /// performance and optimizes nicely for small multiplications.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_ilimb(self, n: $crate::ILimb) -> Self {
             let limbs = $crate::math::mul::wrapping_ilimb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -152,10 +164,12 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by an unsigned limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do. This always
-        /// wraps, which can never happen in practice. This has to use
-        /// the floor division since we can never have a non-negative rem.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice. This
+        /// has to use the floor division since we can never have a non-
+        /// negative rem.
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_ulimb(self, n: $crate::ULimb) -> (Self, $crate::ULimb) {
             let x = self.unsigned_abs().to_le_limbs();
             let (div, mut rem) = $crate::math::div::limb(&x, n);
@@ -177,9 +191,10 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by a signed limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do. This always
-        /// wraps, which can never happen in practice.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice.
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_ilimb(self, n: $crate::ILimb) -> (Self, $crate::ILimb) {
             let x = self.unsigned_abs().to_le_limbs();
             let (div, rem) = $crate::math::div::limb(&x, n.unsigned_abs());
@@ -203,8 +218,9 @@ macro_rules! define {
         /// Get the quotient of our big integer divided
         /// by a signed limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_ilimb(self, n: $crate::ILimb) -> Self {
             self.wrapping_div_rem_ilimb(n).0
         }
@@ -212,8 +228,9 @@ macro_rules! define {
         /// Get the remainder of our big integer divided
         /// by a signed limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_ilimb(self, n: $crate::ILimb) -> $crate::ILimb {
             self.wrapping_div_rem_ilimb(n).1
         }
@@ -225,8 +242,9 @@ macro_rules! define {
         /// Add an unsigned limb to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::add::overflowing_ulimb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -235,8 +253,9 @@ macro_rules! define {
         /// Add a signed limb to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_ilimb(self, n: $crate::ILimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::add::overflowing_ilimb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -245,8 +264,9 @@ macro_rules! define {
         /// Subtract an unsigned limb from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::sub::overflowing_ulimb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -255,8 +275,9 @@ macro_rules! define {
         /// Subtract a signed limb from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_ilimb(self, n: $crate::ILimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::sub::overflowing_ilimb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -265,10 +286,11 @@ macro_rules! define {
         /// Multiply our big integer by an unsigned limb, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         /// This in worst case 4 `mul`, 4 `add`, and 6 `sub` instructions,
         /// significantly slower than the wrapping variant.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::mul::overflowing_ulimb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -277,10 +299,11 @@ macro_rules! define {
         /// Multiply our big integer by a signed limb, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         /// This in worst case 5 `mul`, 5 `add`, and 6 `sub` instructions,
         /// significantly slower than the wrapping variant.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_ilimb(self, n: $crate::ILimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::mul::overflowing_ilimb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -290,8 +313,9 @@ macro_rules! define {
         /// by a signed limb, returning the value and if overflow
         /// occurred.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_rem_ilimb(self, n: $crate::ILimb) -> ((Self, $crate::ILimb), bool) {
             if self.eq_const(Self::MIN) && n == -1 {
                 ((Self::MIN, 0), true)
@@ -304,8 +328,9 @@ macro_rules! define {
         /// by a signed limb, returning the value and if overflow
         /// occurred.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_ilimb(self, n: $crate::ILimb) -> (Self, bool) {
             let (value, overflowed) = self.overflowing_div_rem_ilimb(n);
             (value.0, overflowed)
@@ -315,8 +340,9 @@ macro_rules! define {
         /// by a signed limb, returning the value and if overflow
         /// occurred.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_ilimb(self, n: $crate::ILimb) -> ($crate::ILimb, bool) {
             let (value, overflowed) = self.overflowing_div_rem_ilimb(n);
             (value.1, overflowed)
@@ -328,8 +354,9 @@ macro_rules! define {
 
         /// Add a signed limb to the big integer, returning None on overflow.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_ilimb(self, n: $crate::ILimb) -> Option<Self> {
             let (value, overflowed) = self.overflowing_add_ilimb(n);
             if overflowed {
@@ -341,8 +368,9 @@ macro_rules! define {
 
         /// Subtract a signed limb from the big integer, returning None on overflow.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_ilimb(self, n: $crate::ILimb) -> Option<Self> {
             let (value, overflowed) = self.overflowing_sub_ilimb(n);
             if overflowed {
@@ -354,8 +382,9 @@ macro_rules! define {
 
         /// Multiply our big integer by a signed limb, returning None on overflow.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_ilimb(self, n: $crate::ILimb) -> Option<Self> {
             let (value, overflowed) = self.overflowing_mul_ilimb(n);
             if overflowed {
@@ -368,8 +397,9 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by a signed limb, returning None on overflow or division by 0.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_rem_ilimb(self, n: $crate::ILimb) -> Option<(Self, $crate::ILimb)> {
             if n == 0 {
                 None
@@ -381,8 +411,9 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by a signed
         /// limb, returning None on overflow or division by 0.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_ilimb(self, n: $crate::ILimb) -> Option<Self> {
             Some(self.checked_div_rem_ilimb(n)?.0)
         }
@@ -390,8 +421,9 @@ macro_rules! define {
         /// Get the remainder of our big integer divided by a signed
         /// limb, returning None on overflow or division by 0.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_ilimb(self, n: $crate::ILimb) -> Option<$crate::ILimb> {
             Some(self.checked_div_rem_ilimb(n)?.1)
         }

--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -29,6 +29,7 @@ pub(crate) mod overflowing;
 pub(crate) mod saturating;
 pub(crate) mod strict;
 pub(crate) mod traits;
+pub(crate) mod unchecked;
 pub(crate) mod wrapping;
 
 /// Define a signed integer.
@@ -82,8 +83,8 @@ macro_rules! define {
             $crate::int::overflowing::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
             $crate::int::saturating::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
             $crate::int::checked::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::int::strict::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::shared::unchecked::define!(type => $u_t, wide_type => $wide_s_t);
+            $crate::int::strict::define!(unsigned_type => $u_t);
+            $crate::int::unchecked::define!(unsigned_type => $u_t);
             $crate::shared::unbounded::define!(type => $u_t, wide_type => $wide_s_t);
             $crate::int::limb::define!(@all);
 

--- a/src/int/ops.rs
+++ b/src/int/ops.rs
@@ -56,6 +56,7 @@ macro_rules! define {
         ///
         #[doc = concat!("See [`", stringify!($wide_t), "::unsigned_abs`].")]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn unsigned_abs(self) -> $u_t {
             self.wrapping_abs().as_unsigned()
         }
@@ -73,14 +74,11 @@ macro_rules! define {
         /// towards -infinity; if `rhs < 0`, this is equal to rounding towards
         /// +infinity.
         ///
-        /// # Panics
-        ///
-        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
-        /// and `rhs` is -1. This behavior is not affected by the `overflow-checks`
-        /// flag.
+        #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
         #[doc = concat!("See [`", stringify!($wide_t), "::div_euclid`].")]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_euclid(self, rhs: Self) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_div_euclid(rhs)
@@ -98,14 +96,11 @@ macro_rules! define {
         /// `r = self.rem_euclid(rhs)`, the result satisfies
         /// `self = rhs * self.div_euclid(rhs) + r` and `0 <= r < abs(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
-        /// and `rhs` is -1. This behavior is not affected by the
-        /// `overflow-checks` flag.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::rem_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, rem_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_euclid(self, rhs: Self) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_rem_euclid(rhs)
@@ -120,14 +115,11 @@ macro_rules! define {
         /// Calculates the quotient of `self` and `rhs`, rounding the result towards
         /// negative infinity.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
-        /// and `rhs` is -1. This behavior is not affected by the `overflow-checks`
-        /// flag.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::div_floor`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, div_floor)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_floor(self, rhs: Self) -> Self {
             let (d, r) = self.wrapping_div_rem(rhs);
 
@@ -148,14 +140,11 @@ macro_rules! define {
         /// Calculates the quotient of `self` and `rhs`, rounding the result towards
         /// positive infinity.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        /// This function will panic if `rhs` is zero or if `self` is `Self::MIN`
-        /// and `rhs` is -1. This behavior is not affected by the `overflow-checks`
-        /// flag.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::div_ceil`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, div_ceil)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_ceil(self, rhs: Self) -> Self {
             let (d, r) = self.wrapping_div_rem(rhs);
 
@@ -174,25 +163,22 @@ macro_rules! define {
         /// calculates the largest value less than or equal to `self` that is a
         /// multiple of `rhs`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
+        #[doc = $crate::shared::docs::overflow_assertions_doc!()]
         ///
-        /// ## Overflow behavior
-        ///
-        /// On overflow, this function will panic if overflow checks are enabled
-        /// (default in debug mode) and wrap if overflow checks are disabled
-        /// (default in release mode).
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::next_multiple_of`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, next_multiple_of)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn next_multiple_of(self, rhs: Self) -> Self {
+            use core::ops::Rem;
+
             if rhs.eq_const(Self::from_i8(-1)) {
                 return self;
             }
 
             let zero = Self::from_u8(0);
-            let r = self.wrapping_rem(rhs);
+            let r = self.rem(rhs);
             let m = if (r > zero && rhs < zero) || (r < zero && rhs > zero) {
                 r + rhs
             } else {
@@ -232,7 +218,7 @@ macro_rules! define {
         /// This function will panic if `self` is less than or equal to zero,
         /// or if `base` is less than 2.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::ilog`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, ilog)]
         #[inline(always)]
         pub fn ilog(self, base: Self) -> u32 {
             assert!(
@@ -252,7 +238,7 @@ macro_rules! define {
         ///
         /// This function will panic if `self` is less than or equal to zero.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::ilog2`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, ilog2)]
         #[inline(always)]
         pub const fn ilog2(self) -> u32 {
             if let Some(log) = self.checked_ilog2() {
@@ -279,8 +265,9 @@ macro_rules! define {
 
         /// Computes the absolute value of `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::abs`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, abs)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn abs(self) -> Self {
             match self.checked_abs() {
                 Some(value) => value,
@@ -293,8 +280,9 @@ macro_rules! define {
         /// This function always returns the correct answer without overflow or
         /// panics by returning an unsigned integer.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::abs_diff`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, abs_diff)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn abs_diff(self, other: Self) -> $u_t {
             if self.lt_const(other) {
                 other.as_unsigned().wrapping_sub(self.as_unsigned())
@@ -309,7 +297,7 @@ macro_rules! define {
         ///  - `1` if the number is positive
         ///  - `-1` if the number is negative
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::signum`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, signum)]
         #[inline(always)]
         pub const fn signum(self) -> Self {
             match self.cmp_const(Self::from_u8(0)) {
@@ -326,9 +314,9 @@ macro_rules! define {
         /// result is always rounded towards negative infinity and that no
         /// overflow will ever occur.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::midpoint`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, midpoint)]
         #[inline]
-        #[must_use]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn midpoint(self, rhs: Self) -> Self {
             // Use the well known branchless algorithm from Hacker's Delight to compute
             // `(a + b) / 2` without overflowing: `((a ^ b) >> 1) + (a & b)`.

--- a/src/int/overflowing.rs
+++ b/src/int/overflowing.rs
@@ -11,7 +11,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would have
         /// occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_add)]
         #[inline(always)]
         pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
@@ -26,7 +26,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_sub)]
         #[inline(always)]
         pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
@@ -41,7 +41,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_add_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_add_unsigned)]
         #[inline(always)]
         pub const fn overflowing_add_unsigned(self, rhs: $u_t) -> (Self, bool) {
             let rhs = rhs.as_signed();
@@ -55,7 +55,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_sub_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_sub_unsigned)]
         #[inline(always)]
         pub const fn overflowing_sub_unsigned(self, rhs: $u_t) -> (Self, bool) {
             let rhs = rhs.as_signed();
@@ -72,7 +72,7 @@ macro_rules! define {
         /// This in worst case 10 `mul`, 20 `add`, and 9 `sub` instructions,
         /// significantly slower than the wrapping variant.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_mul`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_mul)]
         #[inline(always)]
         pub const fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
@@ -87,11 +87,9 @@ macro_rules! define {
         /// an arithmetic overflow would occur. If an overflow would occur then
         /// self is returned.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_div)]
         #[inline(always)]
         pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -107,11 +105,9 @@ macro_rules! define {
         /// an arithmetic overflow would occur. If an overflow would occur then
         /// `self` is returned.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_div_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_div_euclid)]
         #[inline(always)]
         pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -127,11 +123,9 @@ macro_rules! define {
         /// indicating whether an arithmetic overflow would occur. If an
         /// overflow would occur then 0 is returned.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_rem`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_rem)]
         #[inline(always)]
         pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -147,11 +141,9 @@ macro_rules! define {
         /// indicating whether an arithmetic overflow would occur. If an
         /// overflow would occur then 0 is returned.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_rem_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_rem_euclid)]
         #[inline(always)]
         pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -169,7 +161,7 @@ macro_rules! define {
         /// minimum value will be returned again and `true` will be returned for an
         /// overflow happening.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_neg`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_neg)]
         #[inline(always)]
         pub const fn overflowing_neg(self) -> (Self, bool) {
             if self.eq_const(Self::MIN) {
@@ -187,7 +179,7 @@ macro_rules! define {
         /// masked (N-1) where N is the number of bits, and this value is then used
         /// to perform the shift.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_shl`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_shl)]
         #[inline(always)]
         pub const fn overflowing_shl(self, rhs: u32) -> (Self, bool) {
             (self.wrapping_shl(rhs), rhs >= Self::BITS)
@@ -201,7 +193,7 @@ macro_rules! define {
         /// masked (N-1) where N is the number of bits, and this value is then used
         /// to perform the shift.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_shr`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_shr)]
         #[inline(always)]
         pub const fn overflowing_shr(self, rhs: u32) -> (Self, bool) {
             (self.wrapping_shr(rhs), rhs >= Self::BITS)
@@ -212,7 +204,7 @@ macro_rules! define {
         /// Returns a tuple of the absolute version of self along with a boolean
         /// indicating whether an overflow happened.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_abs`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_abs)]
         #[inline(always)]
         pub const fn overflowing_abs(self) -> (Self, bool) {
             match self.is_negative() {

--- a/src/int/saturating.rs
+++ b/src/int/saturating.rs
@@ -8,8 +8,9 @@ macro_rules! define {
         /// Saturating integer addition. Computes `self + rhs`, saturating at the
         /// numeric bounds instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_add)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add(self, rhs: Self) -> Self {
             match self.checked_add(rhs) {
                 Some(value) => value,
@@ -21,8 +22,9 @@ macro_rules! define {
         /// Saturating addition with an unsigned integer. Computes `self + rhs`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_add_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_add_unsigned)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add_unsigned(self, rhs: $u_t) -> Self {
             // Overflow can only happen at the upper bound
             // We cannot use `unwrap_or` here because it is not `const`
@@ -35,8 +37,9 @@ macro_rules! define {
         /// Saturating integer subtraction. Computes `self - rhs`, saturating at the
         /// numeric bounds instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_sub)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_sub(self, rhs: Self) -> Self {
             match self.checked_sub(rhs) {
                 Some(value) => value,
@@ -48,8 +51,9 @@ macro_rules! define {
         /// Saturating subtraction with an unsigned integer. Computes `self - rhs`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_sub_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_sub_unsigned)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_sub_unsigned(self, rhs: $u_t) -> Self {
             // Overflow can only happen at the lower bound
             // We cannot use `unwrap_or` here because it is not `const`
@@ -62,8 +66,9 @@ macro_rules! define {
         /// Saturating integer negation. Computes `-self`, returning `MAX` if `self
         /// == MIN` instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_neg`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_neg)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_neg(self) -> Self {
             Self::from_u8(0).saturating_sub(self)
         }
@@ -71,8 +76,9 @@ macro_rules! define {
         /// Saturating absolute value. Computes `self.abs()`, returning `MAX` if
         /// `self == MIN` instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_abs`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_abs)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_abs(self) -> Self {
             match self.checked_abs() {
                 Some(value) => value,
@@ -83,8 +89,9 @@ macro_rules! define {
         /// Saturating integer multiplication. Computes `self * rhs`, saturating at
         /// the numeric bounds instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_mul`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_mul)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_mul(self, rhs: Self) -> Self {
             match self.checked_mul(rhs) {
                 Some(x) => x,
@@ -101,11 +108,10 @@ macro_rules! define {
         /// Saturating integer division. Computes `self / rhs`, saturating at the
         /// numeric bounds instead of overflowing.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_div)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         #[inline(always)]
         pub fn saturating_div(self, rhs: Self) -> Self {
             match self.overflowing_div(rhs) {
@@ -117,8 +123,9 @@ macro_rules! define {
         /// Saturating integer exponentiation. Computes `self.pow(exp)`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_pow`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_pow)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_pow(self, exp: u32) -> Self {
             match self.checked_pow(exp) {
                 Some(x) => x,

--- a/src/int/strict.rs
+++ b/src/int/strict.rs
@@ -2,27 +2,18 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::strict::define!(type => $u_t, wide_type => $wide_t);
+    (unsigned_type => $u_t:ty) => {
+        $crate::shared::strict::define!(type => $u_t, wide_type => i128);
 
         /// Strict addition with an unsigned integer. Computes `self + rhs`,
         /// panicking if overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_add_unsigned`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_add_unsigned)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_add_unsigned(self, rhs: $u_t) -> Self {
             match self.checked_add_unsigned(rhs) {
                 Some(v) => v,
@@ -33,21 +24,12 @@ macro_rules! define {
         /// Strict subtraction with an unsigned integer. Computes `self - rhs`,
         /// panicking if overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_sub_unsigned`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_sub_unsigned)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_sub_unsigned(self, rhs: $u_t) -> Self {
             match self.checked_sub_unsigned(rhs) {
                 Some(v) => v,
@@ -58,27 +40,16 @@ macro_rules! define {
         /// Strict integer division. Computes `self / rhs`, panicking
         /// if overflow occurred.
         ///
-        /// # Panics
-        ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
         /// The only case where such an overflow can occur is when one divides `MIN
         /// / -1` on a signed type (where `MIN` is the negative minimal value
         /// for the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_div`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_div)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_div(self, rhs: Self) -> Self {
             match self.checked_div(rhs) {
                 Some(v) => v,
@@ -89,27 +60,16 @@ macro_rules! define {
         /// Strict integer remainder. Computes `self % rhs`, panicking if
         /// the division results in overflow.
         ///
-        /// # Panics
-        ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
         /// The only case where such an overflow can occur is `x % y` for `MIN / -1`
         /// on a signed type (where `MIN` is the negative minimal value), which
         /// is invalid due to implementation artifacts.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_rem`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_rem)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_rem(self, rhs: Self) -> Self {
             match self.checked_rem(rhs) {
                 Some(v) => v,
@@ -120,28 +80,17 @@ macro_rules! define {
         /// Strict Euclidean division. Computes `self.div_euclid(rhs)`, panicking
         /// if overflow occurred.
         ///
-        /// # Panics
-        ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
         /// The only case where such an overflow can occur is when one divides `MIN
         /// / -1` on a signed type (where `MIN` is the negative minimal value
         /// for the type); this is equivalent to `-MIN`, a positive value
         /// that is too large to represent in the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_div_euclid`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_div_euclid)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_div_euclid(self, rhs: Self) -> Self {
             match self.checked_div_euclid(rhs) {
                 Some(v) => v,
@@ -152,27 +101,16 @@ macro_rules! define {
         /// Strict Euclidean remainder. Computes `self.rem_euclid(rhs)`, panicking
         /// if the division results in overflow.
         ///
-        /// # Panics
-        ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
         /// The only case where such an overflow can occur is `x % y` for `MIN / -1`
         /// on a signed type (where `MIN` is the negative minimal value), which
         /// is invalid due to implementation artifacts.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_rem_euclid`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_rem_euclid)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_rem_euclid(self, rhs: Self) -> Self {
             match self.checked_rem_euclid(rhs) {
                 Some(v) => v,
@@ -182,21 +120,12 @@ macro_rules! define {
 
         /// Strict negation. Computes `-self`, panicking if `self == MIN`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_neg`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_neg)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_neg(self) -> Self {
             match self.checked_neg() {
                 Some(v) => v,
@@ -207,47 +136,16 @@ macro_rules! define {
         /// Strict absolute value. Computes `self.abs()`, panicking if
         /// `self == MIN`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_abs`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_abs)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_abs(self) -> Self {
             match self.checked_abs() {
                 Some(v) => v,
                 None => core::panic!("attempt to negate with overflow"),
-            }
-        }
-
-        /// Unchecked negation. Computes `-self`, assuming overflow cannot occur.
-        ///
-        /// # Safety
-        ///
-        /// This results in undefined behavior when the value overflows.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unchecked_neg`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[must_use]
-        #[inline(always)]
-        pub unsafe fn unchecked_neg(self) -> Self {
-            match self.checked_neg() {
-                Some(value) => value,
-                // SAFETY: this is guaranteed to be safe by the caller.
-                None => unsafe { core::hint::unreachable_unchecked() },
             }
         }
     };

--- a/src/int/unchecked.rs
+++ b/src/int/unchecked.rs
@@ -1,0 +1,29 @@
+//! Unchecked arithmetic operations.
+//!
+//! On overflow or other unexpected cases, this results in
+//! undefined behavior.
+
+#[rustfmt::skip]
+macro_rules! define {
+    (unsigned_type => $u_t:ty) => {
+        $crate::shared::unchecked::define!(type => $u_t, wide_type => i128);
+
+        /// Unchecked negation. Computes `-self`, assuming overflow cannot occur.
+        ///
+        #[doc = $crate::shared::docs::unchecked_doc!()]
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(i128, unchecked_neg)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub unsafe fn unchecked_neg(self) -> Self {
+            match self.checked_neg() {
+                Some(value) => value,
+                // SAFETY: this is guaranteed to be safe by the caller.
+                None => unsafe { core::hint::unreachable_unchecked() },
+            }
+        }
+    }
+}
+
+pub(crate) use define;

--- a/src/int/wrapping.rs
+++ b/src/int/wrapping.rs
@@ -8,8 +8,9 @@ macro_rules! define {
         /// Wrapping (modular) addition. Computes `self + rhs`, wrapping around at
         /// the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_add)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add(self, rhs: Self) -> Self {
             let result = $crate::math::add::wrapping_signed(&self.to_ne_limbs(), &rhs.to_ne_limbs());
             Self::from_ne_limbs(result)
@@ -18,8 +19,9 @@ macro_rules! define {
         /// Wrapping (modular) subtraction. Computes `self - rhs`, wrapping around
         /// at the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_sub)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub(self, rhs: Self) -> Self {
             let result = $crate::math::sub::wrapping_signed(&self.to_ne_limbs(), &rhs.to_ne_limbs());
             Self::from_ne_limbs(result)
@@ -28,8 +30,9 @@ macro_rules! define {
         /// Wrapping (modular) subtraction with an unsigned integer. Computes
         /// `self - rhs`, wrapping around at the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_sub_unsigned`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_sub_unsigned)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_unsigned(self, rhs: $u_t) -> Self {
             self.wrapping_sub(Self::from_unsigned(rhs))
         }
@@ -42,10 +45,11 @@ macro_rules! define {
         /// optimizes nicely for small multiplications. See [`u256::wrapping_mul`]
         /// for a more detailed analysis, which is identical.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_mul`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_mul)]
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
             let limbs = $crate::math::mul::wrapping_signed(&self.to_ne_limbs(), &rhs.to_ne_limbs());
             Self::from_ne_limbs(limbs)
@@ -56,10 +60,9 @@ macro_rules! define {
         /// This allows storing of both the quotient and remainder without
         /// making repeated calls.
         ///
-        /// # Panics
-        ///
-        /// This panics if the divisor is 0.
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem(self, n: Self) -> (Self, Self) {
             // NOTE: Our algorithm assumes little-endian order, which we might not have.
             // So, we transmute to LE order prior to the call.
@@ -100,8 +103,9 @@ macro_rules! define {
         ///
         /// This function will panic if `rhs` is zero.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_div)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div(self, rhs: Self) -> Self {
             self.wrapping_div_rem(rhs).0
         }
@@ -118,8 +122,9 @@ macro_rules! define {
         ///
         /// This function will panic if `rhs` is zero.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_div_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_div_euclid)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
             let (mut q, r) = self.wrapping_div_rem(rhs);
             if r.is_negative() {
@@ -144,8 +149,9 @@ macro_rules! define {
         ///
         /// This function will panic if `rhs` is zero.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_rem`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_rem)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem(self, rhs: Self) -> Self {
             self.wrapping_div_rem(rhs).1
         }
@@ -157,8 +163,9 @@ macro_rules! define {
         /// the negative minimal value for the type). In this case, this method
         /// returns 0.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_rem_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_rem_euclid)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
             let r = self.wrapping_rem(rhs);
             if r.is_negative() {
@@ -184,8 +191,9 @@ macro_rules! define {
         /// type); this is a positive value that is too large to represent
         /// in the type. In such a case, this function returns `MIN` itself.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_neg`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_neg)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_neg(self) -> Self {
             // NOTE: This is identical to `add(not(x), 1i256)`
             let twos_neg = self.not_const().wrapping_add_ulimb(1);
@@ -202,8 +210,9 @@ macro_rules! define {
         /// positive value that is too large to represent in the type. In such a
         /// case, this function returns `MIN` itself.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_abs`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_abs)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_abs(self) -> Self {
             self.overflowing_abs().0
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@
 //! - [`num-bigint`], [`malachite`], or [`rug`]: Dynamic-width big integers with
 //!   high-
 //! performance calculations with very large integers.
-
+//!
 //! Specifically, [`i256`] has optimizations that would be considered
 //! anti-features for these libraries: better performance for smaller values
 //! (variable-time calculations) and operations with native, scalar values. This

--- a/src/shared/bigint.rs
+++ b/src/shared/bigint.rs
@@ -13,14 +13,10 @@ macro_rules! define {
         /// chaining together multiple additions to create a wider addition, and
         /// can be useful for bignum addition.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::carrying_add`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, carrying_add)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline]
-        #[must_use]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn carrying_add(self, rhs: Self, carry: bool) -> (Self, bool) {
             let (a, b) = self.overflowing_add(rhs);
             let (c, d) = a.overflowing_add_ulimb(carry as $crate::ULimb);
@@ -36,12 +32,8 @@ macro_rules! define {
         /// subtractions to create a wider subtraction, and can be useful for
         /// bignum subtraction.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::borrowing_sub`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, borrowing_sub)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline]
         #[must_use]
         pub const fn borrowing_sub(self, rhs: Self, borrow: bool) -> (Self, bool) {

--- a/src/shared/casts.rs
+++ b/src/shared/casts.rs
@@ -50,19 +50,19 @@ macro_rules! define {
         bits => $bits:expr,
         kind => $kind:ident $(,)?
     ) => {
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a `u8`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`u8`]")]
         #[inline(always)]
         pub const fn from_u8(value: u8) -> Self {
             Self::from_u32(value as u32)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a `u16`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`u16`]")]
         #[inline(always)]
         pub const fn from_u16(value: u16) -> Self {
             Self::from_u32(value as u32)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a `u32`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`u32`]")]
         #[inline(always)]
         pub const fn from_u32(value: u32) -> Self {
             let mut limbs = [0; Self::LIMBS];
@@ -70,7 +70,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a `u64`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`u64`]")]
         #[inline(always)]
         pub const fn from_u64(value: u64) -> Self {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -86,7 +86,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a `u128`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`u128`]")]
         #[inline(always)]
         pub const fn from_u128(value: u128) -> Self {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -105,7 +105,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an unsigned limb, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`ULimb`][crate::ULimb]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn from_ulimb(value: $crate::ULimb) -> Self {
@@ -118,7 +118,7 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an unsigned wide type, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`UWide`][crate::UWide]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn from_uwide(value: $crate::UWide) -> Self {
@@ -131,31 +131,31 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an unsigned integer, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, concat!("[`", stringify!($u_t), "`]"))]
         #[inline(always)]
         pub const fn from_unsigned(value: $u_t) -> Self {
             Self::from_ne_limbs(value.to_ne_limbs())
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a signed integer, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, concat!("[`", stringify!($s_t), "`]"))]
         #[inline(always)]
         pub const fn from_signed(value: $s_t) -> Self {
             Self::from_ne_limbs(value.to_ne_limbs())
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an `i8`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`i8`]")]
         #[inline(always)]
         pub const fn from_i8(value: i8) -> Self {
             Self::from_i32(value as i32)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an `i16`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`i16`]")]
         #[inline(always)]
         pub const fn from_i16(value: i16) -> Self {
             Self::from_i32(value as i32)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an `i32`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`i32`]")]
         #[inline(always)]
         pub const fn from_i32(value: i32) -> Self {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -171,7 +171,7 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from an `i64`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`i64`]")]
         #[inline(always)]
         pub const fn from_i64(value: i64) -> Self {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -187,8 +187,7 @@ macro_rules! define {
             }
         }
 
-        /// Create the 256-bit unsigned integer from an `i128`, as if by an `as`
-        /// cast.
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`i128`]")]
         #[inline(always)]
         pub const fn from_i128(value: i128) -> Self {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -209,7 +208,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a signed limb, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`ILimb`][crate::ILimb]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn from_ilimb(value: $crate::ILimb) -> Self {
@@ -222,7 +221,7 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from a wide type, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::from_cast_doc!($bits, $kind, "[`IWide`][crate::IWide]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn from_iwide(value: $crate::IWide) -> Self {
@@ -235,19 +234,19 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to a `u8`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`u8`]")]
         #[inline(always)]
         pub const fn as_u8(&self) -> u8 {
             self.as_u32() as u8
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to a `u16`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`u16`]")]
         #[inline(always)]
         pub const fn as_u16(&self) -> u16 {
             self.as_u32() as u16
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to a `u32`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`u32`]")]
         #[inline(always)]
         pub const fn as_u32(&self) -> u32 {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -256,7 +255,7 @@ macro_rules! define {
             ne_index!(limbs[0]) as u32
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to a `u64`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`u64`]")]
         #[inline(always)]
         pub const fn as_u64(&self) -> u64 {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -272,20 +271,7 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " an unsigned limb, as if by an `as` cast.")]
-        #[inline(always)]
-        #[allow(clippy::unnecessary_cast)]
-        pub const fn as_ulimb(&self) -> $crate::ULimb {
-            const BITS: u32 = $crate::ULimb::BITS;
-            assert!(BITS == 32 || BITS == 64);
-            if BITS == 32 {
-                self.as_u32() as $crate::ULimb
-            } else {
-                self.as_u64() as $crate::ULimb
-            }
-        }
-
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to a `u128`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`u128`]")]
         #[inline(always)]
         pub const fn as_u128(&self) -> u128 {
             const BITS: u32 = $crate::ULimb::BITS;
@@ -305,7 +291,20 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " an unsigned wide type, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`ULimb`][crate::ULimb]")]
+        #[inline(always)]
+        #[allow(clippy::unnecessary_cast)]
+        pub const fn as_ulimb(&self) -> $crate::ULimb {
+            const BITS: u32 = $crate::ULimb::BITS;
+            assert!(BITS == 32 || BITS == 64);
+            if BITS == 32 {
+                self.as_u32() as $crate::ULimb
+            } else {
+                self.as_u64() as $crate::ULimb
+            }
+        }
+
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`UWide`][crate::UWide]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn as_uwide(&self) -> $crate::UWide {
@@ -318,57 +317,57 @@ macro_rules! define {
             }
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to an `i8`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`i8`]")]
         #[inline(always)]
         pub const fn as_i8(&self) -> i8 {
             self.as_u8() as i8
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to an `i16`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`i16`]")]
         #[inline(always)]
         pub const fn as_i16(&self) -> i16 {
             self.as_u16() as i16
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to an `i32`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`i32`]")]
         #[inline(always)]
         pub const fn as_i32(&self) -> i32 {
             self.as_u32() as i32
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to an `i64`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`i64`]")]
         #[inline(always)]
         pub const fn as_i64(&self) -> i64 {
             self.as_u64() as i64
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " to a `i128`, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`i128`]")]
         #[inline(always)]
         pub const fn as_i128(&self) -> i128 {
             self.as_u128() as i128
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " a signed limb, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`ILimb`][crate::ILimb]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn as_ilimb(&self) -> $crate::ILimb {
             self.as_ulimb() as $crate::ILimb
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " a signed wide type, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, "[`IWide`][crate::IWide]")]
         #[inline(always)]
         #[allow(clippy::unnecessary_cast)]
         pub const fn as_iwide(&self) -> $crate::IWide {
             self.as_uwide() as $crate::IWide
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " unsigned integer to the unsigned type, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, concat!("[`", stringify!($u_t), "`]"))]
         #[inline(always)]
         pub const fn as_unsigned(&self) -> $u_t {
             <$u_t>::from_ne_limbs(self.to_ne_limbs())
         }
 
-        #[doc = concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " unsigned integer to the signed type, as if by an `as` cast.")]
+        #[doc = $crate::shared::docs::as_cast_doc!($bits, $kind, concat!("[`", stringify!($s_t), "`]"))]
         #[inline(always)]
         pub const fn as_signed(&self) -> $s_t {
             <$s_t>::from_ne_limbs(self.to_ne_limbs())

--- a/src/shared/checked.rs
+++ b/src/shared/checked.rs
@@ -6,8 +6,9 @@ macro_rules! define {
         /// Checked integer addition. Computes `self + rhs`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_add)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add(self, rhs: Self) -> Option<Self> {
             let (value, overflowed) = self.overflowing_add(rhs);
             if !overflowed {
@@ -20,8 +21,9 @@ macro_rules! define {
         /// Checked integer subtraction. Computes `self - rhs`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_sub)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
             let (value, overflowed) = self.overflowing_sub(rhs);
             if !overflowed {
@@ -34,8 +36,9 @@ macro_rules! define {
         /// Checked integer multiplication. Computes `self * rhs`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_mul`].")]
-        #[inline(always)]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_mul)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
             if !Self::IS_SIGNED {
                 // quick optimization: if we have 2, 2^N * 2^M will be 2^(N+M),
@@ -58,8 +61,9 @@ macro_rules! define {
         /// Checked exponentiation. Computes `self.pow(exp)`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_pow`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_pow)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_pow(self, base: u32) -> Option<Self> {
             match self.overflowing_pow(base) {
                 (value, false) => Some(value),
@@ -72,7 +76,8 @@ macro_rules! define {
         ///
         /// This allows storing of both the quotient and remainder without
         /// making repeated calls.
-        #[inline]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_rem(self, n: Self) -> Option<(Self, Self)> {
             if self.is_div_none(n) {
                 None
@@ -84,8 +89,9 @@ macro_rules! define {
         /// Checked integer division. Computes `self / rhs`, returning `None`
         /// `rhs == 0` or the division results in overflow (signed only).
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_div)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div(self, rhs: Self) -> Option<Self> {
             if self.is_div_none(rhs) {
                 None
@@ -97,8 +103,9 @@ macro_rules! define {
         /// Checked integer division. Computes `self % rhs`, returning `None`
         /// `rhs == 0` or the division results in overflow (signed only).
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_rem`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_rem)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem(self, rhs: Self) -> Option<Self> {
             if self.is_div_none(rhs) {
                 None
@@ -111,8 +118,9 @@ macro_rules! define {
         /// returning `None` if `rhs == 0` or the division results in
         /// overflow (signed only).
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_div_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_div_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
             if self.is_div_none(rhs) {
                 None
@@ -125,8 +133,9 @@ macro_rules! define {
         /// returning `None` if `rhs == 0` or the division results in
         /// overflow (signed only).
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_rem_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_rem_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
             if self.is_div_none(rhs) {
                 None
@@ -138,8 +147,9 @@ macro_rules! define {
         /// Checked shift left. Computes `self << rhs`, returning `None` if `rhs` is
         /// larger than or equal to the number of bits in `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_shl`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_shl)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
             // Not using overflowing_shl as that's a wrapping shift
             if rhs < Self::BITS {
@@ -152,8 +162,9 @@ macro_rules! define {
         /// Checked shift right. Computes `self >> rhs`, returning `None` if `rhs`
         /// is larger than or equal to the number of bits in `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_shr`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_shr)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
             // Not using overflowing_shr as that's a wrapping shift
             if rhs < Self::BITS {
@@ -167,8 +178,8 @@ macro_rules! define {
         ///
         /// Returns `None` if the number is negative or zero.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_ilog2`].")]
-        #[inline]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_ilog2)]
+        #[inline(always)]
         pub const fn checked_ilog2(self) -> Option<u32> {
             match self.le_const(Self::from_u8(0)) {
                 true => None,

--- a/src/shared/docs.rs
+++ b/src/shared/docs.rs
@@ -1,0 +1,139 @@
+//! Additional, miscellaneous docstrings.
+
+#[rustfmt::skip]
+macro_rules! nightly_doc {
+    () => {
+"
+<div class=\"warning\">
+
+This is a nightly-only experimental API in the Rust core implementation,
+and therefore is subject to change at any time.
+</div>
+"
+    };
+}
+
+pub(crate) use nightly_doc;
+
+#[rustfmt::skip]
+macro_rules! primitive_doc {
+    ($t:ty, $func:ident) => {
+        concat!("See [`", stringify!($t), "::", stringify!($func),"`].")
+    };
+}
+
+pub(crate) use primitive_doc;
+
+#[rustfmt::skip]
+macro_rules! strict_doc {
+    () => {
+"
+## Overflow behavior
+
+This function will always panic on overflow, regardless of whether
+overflow checks are enabled.
+"
+    };
+
+    (panics) => {
+        concat!("# Panics\n\n", $crate::shared::docs::strict_doc!())
+    };
+
+    (div-zero) => {
+        concat!(
+            $crate::shared::docs::div_by_zero_doc!(),
+            "\n\n",
+            $crate::shared::docs::strict_doc!()
+        )
+    };
+}
+
+pub(crate) use strict_doc;
+
+macro_rules! div_by_zero_doc {
+    () => {
+        $crate::shared::docs::div_by_zero_doc!(rhs)
+    };
+
+    ($arg:ident) => {
+        concat!("# Panics\n\nThis function will panic if `", stringify!($arg), "` is zero.")
+    };
+}
+
+pub(crate) use div_by_zero_doc;
+
+macro_rules! div_by_zero_signed_doc {
+    () => {
+        $crate::shared::docs::div_by_zero_signed_doc!(rhs)
+    };
+
+    ($arg:ident) => {
+        concat!("# Panics\n\nThis function will panic if `", stringify!($arg), "` is zero or if `self` is `Self::MIN` and `rhs` is -1.  This behavior is not affected by the `overflow-checks` flag.")
+    };
+}
+
+pub(crate) use div_by_zero_signed_doc;
+
+#[rustfmt::skip]
+macro_rules! unchecked_doc {
+    () => {
+"
+# Safety
+
+This results in undefined behavior when the value overflows.
+"
+    };
+}
+
+pub(crate) use unchecked_doc;
+
+#[rustfmt::skip]
+macro_rules! must_use_copy_doc {
+    () => {
+        "this returns the result of the operation, without modifying the original"
+    };
+}
+
+pub(crate) use must_use_copy_doc;
+
+#[rustfmt::skip]
+macro_rules! overflow_assertions_doc {
+    () => {
+"
+## Overflow behavior
+
+On overflow, this function will panic if overflow checks are enabled
+(default in debug mode) and wrap if overflow checks are disabled
+(default in release mode).
+"
+    };
+}
+
+pub(crate) use overflow_assertions_doc;
+
+#[rustfmt::skip]
+macro_rules! limb_doc {
+    ($op:ident) => {
+        concat!("This allows optimizations a full ", stringify!($op), " cannot do.")
+    };
+}
+
+pub(crate) use limb_doc;
+
+#[rustfmt::skip]
+macro_rules! as_cast_doc {
+    ($bits:literal, $kind:ident, $to:expr) => {
+        concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " integer to ", $to, ", as if by an `as` cast.")
+    };
+}
+
+pub(crate) use as_cast_doc;
+
+#[rustfmt::skip]
+macro_rules! from_cast_doc {
+    ($bits:literal, $kind:ident, $to:expr) => {
+        concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from ", $to, ", as if by an `as` cast.")
+    };
+}
+
+pub(crate) use from_cast_doc;

--- a/src/shared/endian.rs
+++ b/src/shared/endian.rs
@@ -15,8 +15,9 @@ macro_rules! define {
         /// This optimizes very nicely, with efficient `bswap` or `rol`
         /// implementations for each.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::swap_bytes`].")]
-        #[inline]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, swap_bytes)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn swap_bytes(&self) -> Self {
             let mut r = Self {
                 limbs: [0; Self::LIMBS],
@@ -33,8 +34,9 @@ macro_rules! define {
         /// bit becomes the most significant bit, second least-significant bit
         /// becomes second most-significant bit, etc.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::reverse_bits`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, reverse_bits)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn reverse_bits(&self) -> Self {
             let mut r = Self {
                 limbs: [0; Self::LIMBS],
@@ -52,8 +54,9 @@ macro_rules! define {
         /// On big endian this is a no-op. On little endian the bytes are
         /// swapped.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::from_be`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_be)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be(x: Self) -> Self {
             if cfg!(target_endian = "big") {
                 x
@@ -67,8 +70,9 @@ macro_rules! define {
         /// On little endian this is a no-op. On big endian the bytes are
         /// swapped.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::from_le`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_le)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le(x: Self) -> Self {
             if cfg!(target_endian = "little") {
                 x
@@ -82,8 +86,9 @@ macro_rules! define {
         /// On big endian this is a no-op. On little endian the bytes are
         /// swapped.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::to_be`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_be)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be(self) -> Self {
             if cfg!(target_endian = "big") {
                 self
@@ -97,8 +102,9 @@ macro_rules! define {
         /// On little endian this is a no-op. On big endian the bytes are
         /// swapped.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::to_le`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_le)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le(self) -> Self {
             if cfg!(target_endian = "little") {
                 self
@@ -110,8 +116,9 @@ macro_rules! define {
         /// Returns the memory representation of this integer as a byte array in
         /// big-endian (network) byte order.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::to_be_bytes`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_be_bytes)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be_bytes(self) -> [u8; Self::BYTES] {
             self.to_be().to_ne_bytes()
         }
@@ -119,8 +126,9 @@ macro_rules! define {
         /// Returns the memory representation of this integer as a byte array in
         /// little-endian byte order.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::to_le_bytes`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_le_bytes)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le_bytes(self) -> [u8; Self::BYTES] {
             self.to_le().to_ne_bytes()
         }
@@ -132,11 +140,12 @@ macro_rules! define {
         /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate,
         /// instead.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::to_ne_bytes`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_ne_bytes)]
         ///
         /// [`to_be_bytes`]: Self::to_be_bytes
         /// [`to_le_bytes`]: Self::to_le_bytes
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_ne_bytes(self) -> [u8; Self::BYTES] {
             // SAFETY: plain old data
             unsafe {
@@ -147,8 +156,9 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as a byte array in big endian.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::from_be_bytes`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_be_bytes)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be_bytes(bytes: [u8; Self::BYTES]) -> Self {
             Self::from_ne_bytes(bytes).to_be()
         }
@@ -156,8 +166,9 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as a byte array in little endian.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::from_le_bytes`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_le_bytes)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le_bytes(bytes: [u8; Self::BYTES]) -> Self {
             Self::from_ne_bytes(bytes).to_le()
         }
@@ -169,11 +180,12 @@ macro_rules! define {
         /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
         /// appropriate instead.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::from_ne_bytes`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_ne_bytes)]
         ///
         /// [`from_be_bytes`]: Self::from_be_bytes
         /// [`from_le_bytes`]: Self::from_le_bytes
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_ne_bytes(bytes: [u8; Self::BYTES]) -> Self {
             // SAFETY: plain old data
             let limbs = unsafe {
@@ -188,6 +200,7 @@ macro_rules! define {
         /// The value of each limb stays the same, however, the order that each
         /// is stored within the buffer is in big-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be_limbs(self) -> [$crate::ULimb; Self::LIMBS] {
             if cfg!(target_endian = "little") {
                 swap_array!(self.to_ne_limbs())
@@ -202,6 +215,7 @@ macro_rules! define {
         /// The value of each limb stays the same, however, the order that each
         /// is stored within the buffer is in little-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le_limbs(self) -> [$crate::ULimb; Self::LIMBS] {
             if cfg!(target_endian = "little") {
                 self.to_ne_limbs()
@@ -219,6 +233,7 @@ macro_rules! define {
         /// [`to_be_limbs`]: Self::to_be_limbs
         /// [`to_le_limbs`]: Self::to_le_limbs
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_ne_limbs(self) -> [$crate::ULimb; Self::LIMBS] {
             self.limbs
         }
@@ -229,6 +244,7 @@ macro_rules! define {
         /// The value of each limb stays the same, however, the order that each
         /// is stored within the buffer as if it was from big-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be_limbs(limbs: [$crate::ULimb; Self::LIMBS]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_limbs(limbs)
@@ -243,6 +259,7 @@ macro_rules! define {
         /// The value of each limb stays the same, however, the order that each
         /// is stored within the buffer as if it was from little-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le_limbs(limbs: [$crate::ULimb; Self::LIMBS]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_limbs(swap_array!(limbs))
@@ -261,6 +278,7 @@ macro_rules! define {
         /// [`from_be_limbs`]: Self::from_be_limbs
         /// [`from_le_limbs`]: Self::from_le_limbs
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_ne_limbs(limbs: [$crate::ULimb; Self::LIMBS]) -> Self {
             assert!(Self::BITS % 128 == 0, "must have a multiple of 128 for our size.");
             Self {
@@ -271,6 +289,7 @@ macro_rules! define {
         /// Returns the memory representation of this as a series of wide in
         /// big-endian (network) byte order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be_wide(self) -> [$crate::UWide; Self::WIDE] {
             if cfg!(target_endian = "little") {
                 swap_array!(self.to_ne_wide())
@@ -282,6 +301,7 @@ macro_rules! define {
         /// Returns the memory representation of this as a series of wide in
         /// little-endian byte order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le_wide(self) -> [$crate::UWide; Self::WIDE] {
             if cfg!(target_endian = "little") {
                 self.to_ne_wide()
@@ -299,6 +319,7 @@ macro_rules! define {
         /// [`to_be_wide`]: Self::to_be_wide
         /// [`to_le_wide`]: Self::to_le_wide
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_ne_wide(self) -> [$crate::UWide; Self::WIDE] {
             let bytes = self.to_ne_bytes();
             // SAFETY: plain old data
@@ -310,6 +331,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as a wide type in big endian.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be_wide(wide: [$crate::UWide; Self::WIDE]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_wide(wide)
@@ -321,6 +343,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as a wide type in little endian.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le_wide(wide: [$crate::UWide; Self::WIDE]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_wide(swap_array!(wide))
@@ -339,6 +362,7 @@ macro_rules! define {
         /// [`from_be_wide`]: Self::from_be_wide
         /// [`from_le_wide`]: Self::from_le_wide
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_ne_wide(wide: [$crate::UWide; Self::WIDE]) -> Self {
             // SAFETY: plain old data
             let bytes = unsafe {
@@ -350,6 +374,7 @@ macro_rules! define {
         /// Returns the memory representation of this as a series of `u32` digits
         /// in big-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be_u32(self) -> [u32; Self::U32_LEN] {
             if cfg!(target_endian = "little") {
                 swap_array!(self.to_ne_u32())
@@ -361,6 +386,7 @@ macro_rules! define {
         /// Returns the memory representation of this as a series of `u32` digits
         /// in litte-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le_u32(self) -> [u32; Self::U32_LEN] {
             if cfg!(target_endian = "little") {
                 self.to_ne_u32()
@@ -378,6 +404,7 @@ macro_rules! define {
         /// [`to_be_u32`]: Self::to_be_u32
         /// [`to_le_u32`]: Self::to_le_u32
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_ne_u32(self) -> [u32; Self::U32_LEN] {
             let bytes = self.to_ne_bytes();
             // SAFETY: plain old data
@@ -389,6 +416,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as `u32` elements in big-endian.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be_u32(value: [u32; Self::U32_LEN]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_u32(value)
@@ -400,6 +428,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as `u32` elements in little-endian.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le_u32(value: [u32; Self::U32_LEN]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_u32(swap_array!(value))
@@ -418,6 +447,7 @@ macro_rules! define {
         /// [`from_be_u32`]: Self::from_be_u32
         /// [`from_le_u32`]: Self::from_le_u32
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_ne_u32(value: [u32; Self::U32_LEN]) -> Self {
             // SAFETY: plain old data
             let bytes = unsafe {
@@ -429,6 +459,7 @@ macro_rules! define {
         /// Returns the memory representation of this as a series of `u64` digits
         /// in big-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be_u64(self) -> [u64; Self::U64_LEN] {
             if cfg!(target_endian = "little") {
                 swap_array!(self.to_ne_u64())
@@ -440,6 +471,7 @@ macro_rules! define {
         /// Returns the memory representation of this as a series of `u64` digits
         /// in litte-endian order.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le_u64(self) -> [u64; Self::U64_LEN] {
             if cfg!(target_endian = "little") {
                 self.to_ne_u64()
@@ -457,6 +489,7 @@ macro_rules! define {
         /// [`to_be_u64`]: Self::to_be_u64
         /// [`to_le_u64`]: Self::to_le_u64
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_ne_u64(self) -> [u64; Self::U64_LEN] {
             let bytes = self.to_ne_bytes();
             // SAFETY: plain old data
@@ -468,6 +501,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as `u64` elements in big-endian.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be_u64(value: [u64; Self::U64_LEN]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_u64(value)
@@ -479,6 +513,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as `u64` elements in little-endian.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le_u64(value: [u64; Self::U64_LEN]) -> Self {
             if cfg!(target_endian = "big") {
                 Self::from_ne_u64(swap_array!(value))
@@ -497,6 +532,7 @@ macro_rules! define {
         /// [`from_be_u64`]: Self::from_be_u64
         /// [`from_le_u64`]: Self::from_le_u64
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_ne_u64(value: [u64; Self::U64_LEN]) -> Self {
             // SAFETY: plain old data
             let bytes = unsafe {

--- a/src/shared/limb.rs
+++ b/src/shared/limb.rs
@@ -4,8 +4,9 @@ macro_rules! define {
     () => {
         /// Add an unsigned limb to the big integer.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_ulimb(self, n: $crate::ULimb) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_add_ulimb(n)
@@ -19,8 +20,9 @@ macro_rules! define {
 
         /// Subtract an unsigned limb from the big integer.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_ulimb(self, n: $crate::ULimb) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_sub_ulimb(n)
@@ -34,8 +36,9 @@ macro_rules! define {
 
         /// Multiply our big integer by an unsigned limb.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_ulimb(self, n: $crate::ULimb) -> Self {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_mul_ulimb(n)
@@ -50,12 +53,13 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by an unsigned limb.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         ///
         /// # Panics
         ///
         /// This panics if the divisor is 0.
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_ulimb(self, n: $crate::ULimb) -> (Self, $crate::ULimb) {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_div_rem_ulimb(n)
@@ -69,16 +73,18 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by an unsigned limb.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_ulimb(self, n: $crate::ULimb) -> Self {
             self.div_rem_ulimb(n).0
         }
 
         /// Get the remainder of our big integer divided by an unsigned limb.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_ulimb(self, n: $crate::ULimb) -> $crate::ULimb {
             self.div_rem_ulimb(n).1
         }
@@ -88,8 +94,9 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by an unsigned limb,
         /// wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_ulimb(self, n: $crate::ULimb) -> Self {
             self.wrapping_div_rem_ulimb(n).0
         }
@@ -97,8 +104,9 @@ macro_rules! define {
         /// Get the remainder of our big integer divided by an unsigned limb,
         /// wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_ulimb(self, n: $crate::ULimb) -> $crate::ULimb {
             self.wrapping_div_rem_ulimb(n).1
         }
@@ -109,7 +117,7 @@ macro_rules! define {
         /// by an unsigned limb, returning the value and if overflow
         /// occurred.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
         pub fn overflowing_div_rem_ulimb(self, n: $crate::ULimb) -> ((Self, $crate::ULimb), bool) {
             (self.wrapping_div_rem_ulimb(n), false)
@@ -119,8 +127,9 @@ macro_rules! define {
         /// by an unsigned limb, returning the value and if overflow
         /// occurred.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (value, overflowed) = self.overflowing_div_rem_ulimb(n);
             (value.0, overflowed)
@@ -130,8 +139,9 @@ macro_rules! define {
         /// by an unsigned limb, returning the value and if overflow
         /// occurred.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_ulimb(self, n: $crate::ULimb) -> ($crate::ULimb, bool) {
             let (value, overflowed) = self.overflowing_div_rem_ulimb(n);
             (value.1, overflowed)
@@ -141,8 +151,9 @@ macro_rules! define {
     (@checked) => {
         /// Add an unsigned limb to the big integer, returning None on overflow.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_ulimb(self, n: $crate::ULimb) -> Option<Self> {
             let (value, overflowed) = self.overflowing_add_ulimb(n);
             if overflowed {
@@ -154,8 +165,9 @@ macro_rules! define {
 
         /// Subtract an unsigned limb from the big integer, returning None on overflow.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_ulimb(self, n: $crate::ULimb) -> Option<Self> {
             let (value, overflowed) = self.overflowing_sub_ulimb(n);
             if overflowed {
@@ -167,8 +179,9 @@ macro_rules! define {
 
         /// Multiply our big integer by an unsigned limb, returning None on overflow.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_ulimb(self, n: $crate::ULimb) -> Option<Self> {
             let (value, overflowed) = self.overflowing_mul_ulimb(n);
             if overflowed {
@@ -181,7 +194,7 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by an unsigned
         /// limb, returning None on overflow or division by 0.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
         pub fn checked_div_rem_ulimb(self, n: $crate::ULimb) -> Option<(Self, $crate::ULimb)> {
             if n == 0 {
@@ -194,8 +207,9 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by an unsigned
         /// limb, returning None on overflow or division by 0.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_ulimb(self, n: $crate::ULimb) -> Option<Self> {
             Some(self.checked_div_rem_ulimb(n)?.0)
         }
@@ -203,8 +217,9 @@ macro_rules! define {
         /// Get the remainder of our big integer divided by a signed
         /// limb, returning None on overflow or division by 0.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_ulimb(self, n: $crate::ULimb) -> Option<$crate::ULimb> {
             Some(self.checked_div_rem_ulimb(n)?.1)
         }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -9,6 +9,7 @@ pub(crate) mod bitops;
 pub(crate) mod casts;
 pub(crate) mod checked;
 pub(crate) mod constants;
+pub(crate) mod docs;
 pub(crate) mod endian;
 pub(crate) mod extensions;
 pub(crate) mod limb;

--- a/src/shared/ops.rs
+++ b/src/shared/ops.rs
@@ -11,7 +11,7 @@ macro_rules! define {
     (type => $t:ty,wide_type => $wide_t:ty) => {
         /// Raises self to the power of `exp`, using exponentiation by squaring.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::pow`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, pow)]
         #[inline]
         pub const fn pow(self, exp: u32) -> Self {
             if cfg!(not(have_overflow_checks)) {
@@ -26,10 +26,9 @@ macro_rules! define {
         /// This allows storing of both the quotient and remainder without
         /// making repeated calls.
         ///
-        /// # Panics
-        ///
-        /// This panics if the divisor is 0.
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem(self, n: Self) -> (Self, Self) {
             if cfg!(not(have_overflow_checks)) {
                 self.wrapping_div_rem(n)

--- a/src/shared/overflowing.rs
+++ b/src/shared/overflowing.rs
@@ -9,8 +9,9 @@ macro_rules! define {
         /// Returns a tuple of the exponentiation along with a bool indicating
         /// whether an overflow happened.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_pow`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, overflowing_pow)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_pow(self, mut exp: u32) -> (Self, bool) {
             if exp == 0 {
                 return (Self::from_u8(1), false);
@@ -46,10 +47,9 @@ macro_rules! define {
         /// This allows storing of both the quotient and remainder without
         /// making repeated calls.
         ///
-        /// # Panics
-        ///
-        /// This function will panic if `rhs` is zero.
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_rem(self, n: Self) -> ((Self, Self), bool) {
             if self.is_div_overflow(n) {
                 ((self, Self::from_u8(0)), true)

--- a/src/shared/strict.rs
+++ b/src/shared/strict.rs
@@ -6,21 +6,12 @@ macro_rules! define {
         /// Strict integer addition. Computes `self + rhs`, panicking
         /// if overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_add`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_add)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_add(self, rhs: Self) -> Self {
             match self.checked_add(rhs) {
                 Some(v) => v,
@@ -31,21 +22,12 @@ macro_rules! define {
         /// Strict integer subtraction. Computes `self - rhs`, panicking if
         /// overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_sub`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_sub)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_sub(self, rhs: Self) -> Self {
             match self.checked_sub(rhs) {
                 Some(v) => v,
@@ -56,21 +38,12 @@ macro_rules! define {
         /// Strict integer multiplication. Computes `self * rhs`, panicking if
         /// overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_mul`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_mul)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_mul(self, rhs: Self) -> Self {
             match self.checked_mul(rhs) {
                 Some(v) => v,
@@ -81,21 +54,12 @@ macro_rules! define {
         /// Strict exponentiation. Computes `self.pow(exp)`, panicking if
         /// overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_pow`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_pow)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_pow(self, rhs: u32) -> Self {
             match self.checked_pow(rhs) {
                 Some(v) => v,
@@ -106,21 +70,12 @@ macro_rules! define {
         /// Strict shift left. Computes `self << rhs`, panicking if `rhs` is larger
         /// than or equal to the number of bits in `self`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_shl`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_shl)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_shl(self, rhs: u32) -> Self {
             match self.checked_shl(rhs) {
                 Some(v) => v,
@@ -131,21 +86,12 @@ macro_rules! define {
         /// Strict shift right. Computes `self >> rhs`, panicking `rhs` is
         /// larger than or equal to the number of bits in `self`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_shr`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_shr)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_shr(self, rhs: u32) -> Self {
             match self.checked_shr(rhs) {
                 Some(v) => v,

--- a/src/shared/unbounded.rs
+++ b/src/shared/unbounded.rs
@@ -9,12 +9,9 @@ macro_rules! define {
         /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline]
-        #[must_use]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn unbounded_shl(self, rhs: u32) -> Self {
             if rhs < Self::BITS {
                 self.wrapping_shl(rhs)
@@ -29,12 +26,9 @@ macro_rules! define {
         /// If `rhs` is larger or equal to the number of bits in `self`,
         /// the entire value is shifted out, and `0` is returned.
         ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline]
-        #[must_use]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn unbounded_shr(self, rhs: u32) -> Self {
             if rhs < Self::BITS {
                 self.wrapping_shr(rhs)

--- a/src/shared/unchecked.rs
+++ b/src/shared/unchecked.rs
@@ -15,20 +15,16 @@ macro_rules! define {
         /// If you're just trying to avoid the panic in debug mode, then **do not**
         /// use this.  Instead, you're looking for [`wrapping_add`].
         ///
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
+        #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        /// # Safety
-        ///
-        /// This results in undefined behavior when the value overflows.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unchecked_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_add)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_add`]: Self::checked_add
         /// [`wrapping_add`]: Self::wrapping_add
         /// [`unwrap_unchecked`]: Option::unwrap_unchecked
-        #[must_use]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub unsafe fn unchecked_add(self, rhs: Self) -> Self {
             match self.checked_add(rhs) {
                 Some(value) => value,
@@ -46,20 +42,16 @@ macro_rules! define {
         /// If you're just trying to avoid the panic in debug mode, then **do not**
         /// use this.  Instead, you're looking for [`wrapping_sub`].
         ///
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
+        #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        /// # Safety
-        ///
-        /// This results in undefined behavior when the value overflows.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unchecked_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_sub)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_sub`]: Self::checked_sub
         /// [`wrapping_sub`]: Self::wrapping_sub
         /// [`unwrap_unchecked`]: Option::unwrap_unchecked
-        #[must_use]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub unsafe fn unchecked_sub(self, rhs: Self) -> Self {
             match self.checked_sub(rhs) {
                 Some(value) => value,
@@ -77,20 +69,16 @@ macro_rules! define {
         /// If you're just trying to avoid the panic in debug mode, then **do not**
         /// use this.  Instead, you're looking for [`wrapping_mul`].
         ///
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
+        #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        /// # Safety
-        ///
-        /// This results in undefined behavior when the value overflows.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unchecked_mul`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_mul)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`wrapping_mul`]: Self::wrapping_mul
         /// [`checked_mul`]: Self::checked_mul
         /// [`unwrap_unchecked`]: Option::unwrap_unchecked
-        #[must_use]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const unsafe fn unchecked_mul(self, rhs: Self) -> Self {
             match self.checked_mul(rhs) {
                 Some(value) => value,
@@ -102,20 +90,18 @@ macro_rules! define {
         /// Unchecked shift left. Computes `self << rhs`, assuming that
         /// `rhs` is less than the number of bits in `self`.
         ///
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        ///
         /// # Safety
         ///
         /// This results in undefined behavior if `rhs` is larger than
         /// or equal to the number of bits in `self`,
         /// i.e. when [`checked_shl`] would return `None`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unchecked_shl`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_shl)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_shl`]: Self::checked_shl
-        #[must_use]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const unsafe fn unchecked_shl(self, rhs: u32) -> Self {
             match self.checked_shl(rhs) {
                 Some(value) => value,
@@ -127,20 +113,18 @@ macro_rules! define {
         /// Unchecked shift right. Computes `self >> rhs`, assuming that
         /// `rhs` is less than the number of bits in `self`.
         ///
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        ///
         /// # Safety
         ///
         /// This results in undefined behavior if `rhs` is larger than
         /// or equal to the number of bits in `self`,
         /// i.e. when [`checked_shr`] would return `None`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unchecked_shr`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_shr)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_shr`]: Self::checked_shr
-        #[must_use]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const unsafe fn unchecked_shr(self, rhs: u32) -> Self {
             match self.checked_shr(rhs) {
                 Some(value) => value,

--- a/src/shared/wrapping.rs
+++ b/src/shared/wrapping.rs
@@ -6,8 +6,9 @@ macro_rules! define {
         /// Wrapping (modular) exponentiation. Computes `self.pow(exp)`,
         /// wrapping around at the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_pow`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, wrapping_pow)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_pow(self, mut exp: u32) -> Self {
             if exp == 0 {
                 return Self::from_u8(1);

--- a/src/uint/bitops.rs
+++ b/src/uint/bitops.rs
@@ -5,14 +5,16 @@ macro_rules! define {
         $crate::shared::bitops::define!(type => $s_t, wide_type => $wide_t);
 
         #[inline(always)]
-        #[doc = $crate::shared::bitops::wrapping_shl_doc!($wide_t)]
+        #[doc = $crate::shared::bitops::wrapping_shl_doc!(u128)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             let result = $crate::math::shift::left_uwide(self.to_ne_wide(), rhs % Self::BITS);
             Self::from_ne_wide(result)
         }
 
         #[inline(always)]
-        #[doc = $crate::shared::bitops::wrapping_shr_doc!($wide_t)]
+        #[doc = $crate::shared::bitops::wrapping_shr_doc!(u128)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shr(self, rhs: u32) -> Self {
             let result = $crate::math::shift::right_uwide(self.to_ne_wide(), rhs % Self::BITS);
             Self::from_ne_wide(result)

--- a/src/uint/casts.rs
+++ b/src/uint/casts.rs
@@ -21,8 +21,9 @@ macro_rules! define {
         /// This produces the same result as an `as` cast, but ensures that the
         /// bit-width remains the same.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::cast_signed`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, cast_signed)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn cast_signed(self) -> $s_t {
             self.as_signed()
         }

--- a/src/uint/checked.rs
+++ b/src/uint/checked.rs
@@ -7,8 +7,9 @@ macro_rules! define {
 
         /// Checked addition with a signed integer. Computes `self + rhs`,
         /// returning `None` if overflow occurred.
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_add_signed`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_add_signed)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_signed(self, rhs: $s_t) -> Option<Self> {
             let (value, overflowed) = self.overflowing_add_signed(rhs);
             if !overflowed {
@@ -22,8 +23,9 @@ macro_rules! define {
         /// 0`.
         ///
         /// Note that negating any positive integer will overflow.
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_neg`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_neg)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_neg(self) -> Option<Self> {
             if self.eq_const(Self::MIN) {
                 Some(self)
@@ -40,7 +42,7 @@ macro_rules! define {
         /// This method might not be optimized owing to implementation details;
         /// `checked_ilog2` can produce results more efficiently for base 2, and
         /// `checked_ilog10` can produce results more efficiently for base 10.
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_ilog`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_ilog)]
         #[inline(always)]
         pub fn checked_ilog(self, base: Self) -> Option<u32> {
             let zero = Self::from_u8(0);
@@ -103,8 +105,9 @@ macro_rules! define {
         /// Calculates the smallest value greater than or equal to `self` that
         /// is a multiple of `rhs`. Returns `None` if `rhs` is zero or the
         /// operation would result in overflow.
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_next_multiple_of`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_next_multiple_of)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
             match self.checked_rem(rhs) {
                 None => None,
@@ -117,6 +120,7 @@ macro_rules! define {
         /// Checked subtraction with a signed integer. Computes `self - rhs`,
         /// returning `None` if overflow occurred.
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_signed_diff(self, rhs: Self) -> Option<$s_t> {
             let res = self.wrapping_sub(rhs).as_signed();
             let overflow = self.ge_const(rhs) == res.lt_const(<$s_t>::from_u8(0));
@@ -131,8 +135,9 @@ macro_rules! define {
         /// Returns the smallest power of two greater than or equal to `self`. If
         /// the next power of two is greater than the type's maximum value,
         /// `None` is returned, otherwise the power of two is wrapped in `Some`.
-        #[doc = concat!("See [`", stringify!($wide_t), "::checked_next_power_of_two`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_next_power_of_two)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_next_power_of_two(self) -> Option<Self> {
             self.one_less_than_next_power_of_two().checked_add(Self::from_u8(1))
         }

--- a/src/uint/constants.rs
+++ b/src/uint/constants.rs
@@ -15,14 +15,14 @@ macro_rules! define {
 
         #[deprecated]
         #[inline(always)]
-        #[doc = $crate::shared::constants::min_value_doc!($wide_t)]
+        #[doc = $crate::shared::constants::min_value_doc!(u128)]
         pub const fn min_value() -> Self {
             Self::from_ne_limbs([0; Self::LIMBS])
         }
 
         #[deprecated]
         #[inline(always)]
-        #[doc = $crate::shared::constants::max_value_doc!($wide_t)]
+        #[doc = $crate::shared::constants::max_value_doc!(u128)]
         pub const fn max_value() -> Self {
             Self::from_ne_limbs([$crate::ULimb::MAX; Self::LIMBS])
         }

--- a/src/uint/extensions.rs
+++ b/src/uint/extensions.rs
@@ -38,6 +38,7 @@ macro_rules! define {
         /// Naively, this is [`Self::widening_mul`] and then taking the
         /// high half, however, this can use custom optimizations.
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn high_mul(self, rhs: Self) -> Self {
             // Extract high-and-low masks.
             let x1 = self.high();

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -11,8 +11,9 @@ macro_rules! define {
         /// Add an unsigned limb to the big integer, wrapping on
         /// overflow.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_ulimb(self, n: $crate::ULimb) -> Self {
             let limbs = $crate::math::add::wrapping_limb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -21,8 +22,9 @@ macro_rules! define {
         /// Subtract an unsigned limb from the big integer, wrapping on
         /// overflow.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_ulimb(self, n: $crate::ULimb) -> Self {
             let limbs = $crate::math::sub::wrapping_limb(&self.to_ne_limbs(), n);
             Self::from_ne_limbs(limbs)
@@ -31,7 +33,7 @@ macro_rules! define {
         /// Multiply our big integer by an unsigned limb, wrapping on
         /// overflow.
         ///
-        /// This allows optimizations a full multiplication cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         ///
         /// Many different algorithms were attempted, with a soft [`mulx`] approach
         /// (1), a flat, fixed-width long multiplication (2), and a
@@ -51,6 +53,7 @@ macro_rules! define {
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_ulimb(self, n: $crate::ULimb) -> Self {
             // 256-Bit
             // -------
@@ -86,12 +89,11 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by an unsigned limb, wrapping on overflow.
         ///
-        /// This allows optimizations a full division cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(division)]
         ///
-        /// # Panics
-        ///
-        /// This panics if the divisor is 0.
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_ulimb(self, n: $crate::ULimb) -> (Self, $crate::ULimb) {
             let x = self.to_le_limbs();
             let (div, rem) = $crate::math::div::limb(&x, n);
@@ -106,8 +108,9 @@ macro_rules! define {
         /// Add an unsigned limb to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full addition cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::add::overflowing_limb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -116,8 +119,9 @@ macro_rules! define {
         /// Subtract an unsigned limb from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        /// This allows optimizations a full subtraction cannot do.
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::sub::overflowing_limb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
@@ -125,6 +129,8 @@ macro_rules! define {
 
         /// Multiply our big integer by an unsigned limb, returning the value
         /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         ///
         /// Many different algorithms were attempted, with a soft [`mulx`] approach
         /// (1), a flat, fixed-width long multiplication (2), and a
@@ -145,6 +151,7 @@ macro_rules! define {
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         /// [`wrapping_mul_ulimb`]: Self::wrapping_mul_ulimb
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
             let (limbs, overflowed) = $crate::math::mul::overflowing_limb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)

--- a/src/uint/overflowing.rs
+++ b/src/uint/overflowing.rs
@@ -12,8 +12,9 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_add)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
             let rhs = rhs.to_ne_limbs();
@@ -27,8 +28,9 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_add_signed`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_add_signed)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_signed(self, rhs: $s_t) -> (Self, bool) {
             let is_negative = rhs.is_negative();
             let (r, overflowed) = self.overflowing_add(Self::from_signed(rhs));
@@ -41,8 +43,9 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_sub)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
             let rhs = rhs.to_ne_limbs();
@@ -56,7 +59,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         #[inline]
-        #[must_use]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_signed(self, rhs: $s_t) -> (Self, bool) {
             let (res, overflow) = self.overflowing_sub(rhs.as_unsigned());
             (res, overflow ^ (rhs.is_negative()))
@@ -83,11 +86,12 @@ macro_rules! define {
         ///
         /// The analysis here is practically identical to that of [`wrapping_mul`].
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_mul`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_mul)]
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         /// [`wrapping_mul`]: Self::wrapping_mul
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
             let rhs = rhs.to_ne_limbs();
@@ -102,12 +106,11 @@ macro_rules! define {
         /// integers overflow never occurs, so the second value is always
         /// `false`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_div)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
             (self.wrapping_div(rhs), false)
         }
@@ -122,12 +125,11 @@ macro_rules! define {
         /// definitions of division are equal, this
         /// is exactly equal to `self.overflowing_div(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_div_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_div_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
             self.overflowing_div(rhs)
         }
@@ -139,12 +141,11 @@ macro_rules! define {
         /// unsigned integers overflow never occurs, so the second value is
         /// always `false`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_rem`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_rem)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
             (self.wrapping_rem(rhs), false)
         }
@@ -160,12 +161,11 @@ macro_rules! define {
         /// definitions of division are equal, this operation
         /// is exactly equal to `self.overflowing_rem(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::overflowing_rem_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_rem_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
             self.overflowing_rem(rhs)
         }

--- a/src/uint/saturating.rs
+++ b/src/uint/saturating.rs
@@ -7,8 +7,10 @@ macro_rules! define {
 
         /// Saturating integer addition. Computes `self + rhs`, saturating at
         /// the numeric bounds instead of overflowing.
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_add`].")]
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_add)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add(self, rhs: Self) -> Self {
             match self.checked_add(rhs) {
                 Some(v) => v,
@@ -18,8 +20,10 @@ macro_rules! define {
 
         /// Saturating addition with a signed integer. Computes `self + rhs`,
         /// saturating at the numeric bounds instead of overflowing.
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_add_signed`].")]
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_add_signed)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add_signed(self, rhs: $s_t) -> Self {
             let is_negative = rhs.is_negative();
             let (r, overflowed) = self.overflowing_add(Self::from_signed(rhs));
@@ -34,8 +38,10 @@ macro_rules! define {
 
         /// Saturating integer subtraction. Computes `self - rhs`, saturating
         /// at the numeric bounds instead of overflowing.
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_sub`].")]
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_sub)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_sub(self, rhs: Self) -> Self {
             match self.checked_sub(rhs) {
                 Some(v) => v,
@@ -45,8 +51,10 @@ macro_rules! define {
 
         /// Saturating integer multiplication. Computes `self * rhs`,
         /// saturating at the numeric bounds instead of overflowing.
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_mul`].")]
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_mul)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_mul(self, rhs: Self) -> Self {
             match self.checked_mul(rhs) {
                 Some(v) => v,
@@ -57,11 +65,11 @@ macro_rules! define {
         /// Saturating integer division. Computes `self / rhs`, saturating at the
         /// numeric bounds instead of overflowing.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_div)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn saturating_div(self, rhs: Self) -> Self {
             // on unsigned types, there is no overflow in integer division
             self.wrapping_div(rhs)
@@ -69,8 +77,10 @@ macro_rules! define {
 
         /// Saturating integer exponentiation. Computes `self.pow(exp)`,
         /// saturating at the numeric bounds instead of overflowing.
-        #[doc = concat!("See [`", stringify!($wide_t), "::saturating_pow`].")]
-        #[inline]
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_pow)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_pow(self, exp: u32) -> Self {
             match self.checked_pow(exp) {
                 Some(x) => x,

--- a/src/uint/strict.rs
+++ b/src/uint/strict.rs
@@ -8,24 +8,16 @@ macro_rules! define {
         /// Strict addition with a signed integer. Computes `self + rhs`,
         /// panicking if overflow occurred.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_add_signed`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_add_signed)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_add_signed(self, rhs: $s_t) -> Self {
             match self.checked_add_signed(rhs) {
                 Some(v) => v,
-                None => core::panic!("attempt to add with overflow"),
+                None => core::panic!("attempt to negate with overflow"),
             }
         }
 
@@ -35,21 +27,16 @@ macro_rules! define {
         /// way overflow could ever happen. This function exists so that all
         /// operations are accounted for in the strict operations.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        /// This function will panic if `rhs` is zero.
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_div`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_div)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_div(self, rhs: Self) -> Self {
             match self.checked_div(rhs) {
                 Some(v) => v,
-                None => core::panic!("attempt to divide by zero"),
+                None => core::panic!("attempt to divide with overflow"),
             }
         }
 
@@ -60,21 +47,16 @@ macro_rules! define {
         /// This function exists so that all operations are accounted for in the
         /// strict operations.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        /// This function will panic if `rhs` is zero.
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_rem`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_rem)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_rem(self, rhs: Self) -> Self {
             match self.checked_rem(rhs) {
                 Some(v) => v,
-                None => core::panic!("attempt to divide by zero"),
+                None => core::panic!("attempt to divide with overflow"),
             }
         }
 
@@ -86,21 +68,16 @@ macro_rules! define {
         /// positive integers, all common definitions of division are equal, this
         /// is exactly equal to `self.strict_div(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        /// This function will panic if `rhs` is zero.
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_div_euclid`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_div_euclid)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_div_euclid(self, rhs: Self) -> Self {
             match self.checked_div_euclid(rhs) {
                 Some(v) => v,
-                None => core::panic!("attempt to divide by zero"),
+                None => core::panic!("attempt to divide with overflow"),
             }
         }
 
@@ -113,21 +90,16 @@ macro_rules! define {
         /// definitions of division are equal, this is exactly equal to
         /// `self.strict_rem(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        /// This function will panic if `rhs` is zero.
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_rem_euclid`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_rem_euclid)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn strict_rem_euclid(self, rhs: Self) -> Self {
             match self.checked_rem_euclid(rhs) {
                 Some(v) => v,
-                None => core::panic!("attempt to divide by zero"),
+                None => core::panic!("attempt to divide with overflow"),
             }
         }
 
@@ -136,20 +108,12 @@ macro_rules! define {
         ///
         /// Note that negating any positive integer will overflow.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        /// ## Overflow behavior
-        ///
-        /// This function will always panic on overflow, regardless of whether
-        /// overflow checks are enabled.
-        #[doc = concat!("See [`", stringify!($wide_t), "::strict_neg`].")]
-        ///
-        /// <div class="warning">
-        /// This is a nightly-only experimental API in the Rust core implementation,
-        /// and therefore is subject to change at any time.
-        /// </div>
-        #[inline]
-        #[must_use]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_neg)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn strict_neg(self) -> Self {
             match self.checked_neg() {
                 Some(v) => v,

--- a/src/uint/wrapping.rs
+++ b/src/uint/wrapping.rs
@@ -8,8 +8,9 @@ macro_rules! define {
         /// Wrapping (modular) addition. Computes `self + rhs`,
         /// wrapping around at the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_add`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_add)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add(self, rhs: Self) -> Self {
             let result = $crate::math::add::wrapping_unsigned(&self.to_ne_limbs(), &rhs.to_ne_limbs());
             Self::from_ne_limbs(result)
@@ -18,8 +19,9 @@ macro_rules! define {
         /// Wrapping (modular) addition with a signed integer. Computes
         /// `self + rhs`, wrapping around at the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_add_signed`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_add_signed)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_signed(self, rhs: $s_t) -> Self {
             self.wrapping_add(rhs.as_unsigned())
         }
@@ -27,8 +29,9 @@ macro_rules! define {
         /// Wrapping (modular) subtraction. Computes `self - rhs`,
         /// wrapping around at the boundary of the type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_sub`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_sub)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub(self, rhs: Self) -> Self {
             let result = $crate::math::sub::wrapping_unsigned(&self.to_ne_limbs(), &rhs.to_ne_limbs());
             Self::from_ne_limbs(result)
@@ -62,10 +65,11 @@ macro_rules! define {
         /// because of branching in nearly every case, it has better performance
         /// and optimizes nicely for small multiplications.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_mul`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_mul)]
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul(self, rhs: Self) -> Self {
             // 256-Bit
             // -------
@@ -208,10 +212,9 @@ macro_rules! define {
         /// This allows storing of both the quotient and remainder without
         /// making repeated calls.
         ///
-        /// # Panics
-        ///
-        /// This panics if the divisor is 0.
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
         #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem(self, n: Self) -> (Self, Self) {
             // NOTE: Our algorithm assumes little-endian order, which we might not have.
             let x = self.to_le_limbs();
@@ -230,12 +233,11 @@ macro_rules! define {
         /// no way wrapping could ever happen. This function exists so that all
         /// operations are accounted for in the wrapping operations.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_div`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_div)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div(self, rhs: Self) -> Self {
             self.wrapping_div_rem(rhs).0
         }
@@ -248,12 +250,11 @@ macro_rules! define {
         /// the positive integers, all common definitions of division are equal,
         /// this is exactly equal to `self.wrapping_div(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_div_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_div_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
             self.wrapping_div(rhs)
         }
@@ -265,12 +266,11 @@ macro_rules! define {
         /// This function exists so that all operations are accounted for in the
         /// wrapping operations.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_rem`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_rem)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem(self, rhs: Self) -> Self {
             self.wrapping_div_rem(rhs).1
         }
@@ -284,12 +284,11 @@ macro_rules! define {
         /// definitions of division are equal, this is exactly equal to
         /// `self.wrapping_rem(rhs)`.
         ///
-        /// # Panics
+        #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        /// This function will panic if `rhs` is zero.
-        ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_rem_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_rem_euclid)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
             self.wrapping_rem(rhs)
         }
@@ -304,8 +303,9 @@ macro_rules! define {
         /// Any larger values are equivalent to `MAX + 1 - (val - MAX - 1)` where
         /// `MAX` is the corresponding signed type's maximum.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_neg`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_neg)]
         #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_neg(self) -> Self {
             Self::MIN.wrapping_sub(self)
         }
@@ -314,7 +314,7 @@ macro_rules! define {
         /// the next power of two is greater than the type's maximum value,
         /// the return value is wrapped to `0`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::wrapping_next_power_of_two`].")]
+        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_next_power_of_two)]
         #[inline]
         pub const fn wrapping_next_power_of_two(self) -> Self {
             self.one_less_than_next_power_of_two().wrapping_add(Self::from_u8(1))


### PR DESCRIPTION
This uses macros to auto-generate them. This also adds many `#[must_use]` attributes.