### PR TITLE
Restore the wide APIs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        target: [x86_64, aarch64]
         rust:
           - nightly
           - stable
@@ -59,3 +58,28 @@ jobs:
 
     - name: Doc All Features
       run: RUSTFLAGS="-D warnings" cargo doc --all-features
+
+  features:
+    name: Features
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        features: ["limb32", "stdint", "limb32,stdint"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install Rust toolchain
+      uses: dtolnay/rust-toolchain@nightly
+
+    - name: Check
+      run: cargo check --features=limb32
+
+    - name: Test
+      run: cargo test --features=limb32
+
+    - name: Run Quickcheck Tests
+      run: |
+        cd devel
+        cargo  test --features=limb32

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,70 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Simple",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=i256"
+                ],
+                "filter": {
+                    "name": "i256",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "32-bit Limbs",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--features=limb32",
+                    "--lib",
+                    "--package=i256"
+                ],
+                "filter": {
+                    "name": "i256",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "1.59.0 Support",
+            "cargo": {
+                "args": [
+                    "+1.59.0",
+                    "test",
+                    "--no-run",
+                    "--lib",
+                    "--package=i256"
+                ],
+                "filter": {
+                    "name": "i256",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,10 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- `*_u32`, `*_u64`, and `*_u128` methods for direct API interactions with fixed with integral types, at the potential cost of performance on some architectures.
+
 ## Changed
 
 - Move `I384`, etc. under the `i384`, `i512`, and `i1024` features.
 - Added many `#[must_use]` attributes for expensive operations which create copies of values.
+
+## Fixed
+
+- Restored the `*_uwide` and `*_iwide` API methods.
 
 ## [0.1.12] 2024-12-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,14 +24,16 @@ exclude = [
 ]
 
 [features]
-default = ["std"]
+default = ["std", "stdint"]
 std = []
-i384 = []
+# enable the standard, fixed-width integer APIs for scalar operations.
+stdint = []
 # Enable the `U384` and `I384` types.
-i512 = []
+i384 = []
 # Enable the `U512` and `I512` types.
-i1024 = []
+i512 = []
 # Enable the `U1024` and `I1024` types.
+i1024 = []
 
 # Internal only features.
 # Enable the lint checks.
@@ -59,5 +61,5 @@ debug-assertions = false
 lto = true
 
 [package.metadata.docs.rs]
-features = ["i384", "i512", "i1024"]
+features = ["i384", "i512", "i1024", "stdint"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This crate is optimized for small variants of big integers, but a few additional
 - `i384`: Add the 384-bit I384 and U384 types.
 - `i512`: Add the 512-bit I512 and U512 types.
 - `i1024`: Add the 1024-bit I1024 and U1024 types.
+- `stdint`: Support operations with fixed-width integer types. The `ULimb`, `UWide`, and other scalars defined may vary in size for optimal performance on the target architecture (64-bit multiplies, for example, are more expensive on 32-bit architectures): enabling this API adds in overloads for `u32`, `u64`, and `u128`, guaranteeing API stability across all platforms.
 
 If you need larger integers, [`crypto-bigint`] has high-performance addition, subtraction, and multiplication. With integers with a large number of bits, it uses Karatsuba multiplication, which is significantly asymptotically faster.
 

--- a/devel/.vscode/launch.json
+++ b/devel/.vscode/launch.json
@@ -1,0 +1,82 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Math",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--package=i256-test"
+                ],
+                "filter": {
+                    "name": "native_math"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Ops",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--package=i256-test"
+                ],
+                "filter": {
+                    "name": "ops"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Math - 32-bit Limbs",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--features=limb32",
+                    "--package=i256-test"
+                ],
+                "filter": {
+                    "name": "native_math"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
+            "name": "Ops - 32-bit Limbs",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--features=limb32",
+                    "--package=i256-test"
+                ],
+                "filter": {
+                    "name": "ops"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        }
+    ]
+}

--- a/devel/Cargo.toml
+++ b/devel/Cargo.toml
@@ -19,7 +19,6 @@ serde = { version = "1.0", optional = true, features = ["derive"] }
 serde_json = { version = "1.0", optional = true }
 owo-colors = { version = "4.1", optional = true, features = ["supports-colors"]}
 
-
 [dependencies.i256]
 path = ".."
 default-features = false

--- a/devel/Cargo.toml
+++ b/devel/Cargo.toml
@@ -7,7 +7,8 @@ publish = false
 
 [features]
 std = ["i256/std"]
-default = ["std"]
+stdint = ["i256/stdint"]
+default = ["std", "stdint"]
 noasm = ["i256/noasm"]
 limb32 = ["i256/limb32"]
 "print-benches" = ["serde", "serde_json", "owo-colors"]

--- a/devel/rust-toolchain.toml
+++ b/devel/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -936,7 +936,10 @@ quickcheck! {
             })
         }
     }
+}
 
+#[cfg(feature = "stdint")]
+quickcheck! {
     // 32-bit scalars
 
     fn u256_wrapping_add_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
@@ -1154,9 +1157,228 @@ quickcheck! {
             })
         }
     }
+
+    // 64-bit scalars
+
+    fn u256_wrapping_add_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_u64)
+    }
+
+    fn u256_wrapping_sub_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_u64)
+    }
+
+    fn u256_wrapping_mul_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_u64)
+    }
+
+    fn u256_wrapping_div_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_u64)
+        } else {
+            true
+        }
+    }
+
+    fn u256_wrapping_rem_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_u64, |x, y| {
+                x == i256::u256::from(y)
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_overflowing_add_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_u64)
+    }
+
+    fn u256_overflowing_sub_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_u64)
+    }
+
+    fn u256_overflowing_mul_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_u64)
+    }
+
+    fn u256_overflowing_div_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_u64)
+        } else {
+            true
+        }
+    }
+
+    fn u256_overflowing_rem_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_u64, |x: (i256::u256, bool), y: (u64, bool)| {
+                x.0 == i256::u256::from(y.0) && x.1 == y.1
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_checked_add_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_add, checked_add_u64)
+    }
+
+    fn u256_checked_sub_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_u64)
+    }
+
+    fn u256_checked_mul_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_u64)
+    }
+
+    fn u256_checked_div_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(check x0, x1, y, checked_div, checked_div_u64)
+        } else {
+            true
+        }
+    }
+
+    fn u256_checked_rem_u64_quickcheck(x0: u128, x1: u128, y: u64) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_u64, |x: Option<i256::u256>, y: Option<u64>| {
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::u256::from(v).to_le_bytes())
+            })
+        } else {
+            true
+        }
+    }
+
+    fn i256_wrapping_add_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_u64)
+    }
+
+    fn i256_wrapping_sub_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_u64)
+    }
+
+    fn i256_wrapping_mul_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_u64)
+    }
+
+    fn i256_overflowing_add_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_u64)
+    }
+
+    fn i256_overflowing_sub_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_u64)
+    }
+
+    fn i256_overflowing_mul_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_u64)
+    }
+
+    fn i256_checked_add_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_u64)
+    }
+
+    fn i256_checked_sub_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_u64)
+    }
+
+    fn i256_checked_mul_u64_quickcheck(x0: u128, x1: i128, y: u64) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_u64)
+    }
+
+    fn i256_wrapping_add_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_i64)
+    }
+
+    fn i256_wrapping_sub_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_i64)
+    }
+
+    fn i256_wrapping_mul_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_i64)
+    }
+
+    fn i256_wrapping_div_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_i64)
+        }
+    }
+
+    fn i256_wrapping_rem_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_i64, |x, y| {
+                x == i256::i256::from_i64(y)
+            })
+        }
+    }
+
+    fn i256_overflowing_add_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_i64)
+    }
+
+    fn i256_overflowing_sub_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_i64)
+    }
+
+    fn i256_overflowing_mul_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_i64)
+    }
+
+    fn i256_overflowing_div_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_i64)
+        }
+    }
+
+    fn i256_overflowing_rem_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_i64, |x: (i256::i256, bool), y: (i64, bool)| {
+                x.0 == i256::i256::from(y.0) && x.1 == y.1
+            })
+        }
+    }
+
+    fn i256_checked_add_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_i64)
+    }
+
+    fn i256_checked_sub_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_i64)
+    }
+
+    fn i256_checked_mul_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_i64)
+    }
+
+    fn i256_checked_div_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(check x0, x1, y, checked_div, checked_div_i64)
+        }
+    }
+
+    fn i256_checked_rem_i64_quickcheck(x0: u128, x1: i128, y: i64) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_i64, |x: Option<i256::i256>, y: Option<i64>| {
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::i256::from(v).to_le_bytes())
+            })
+        }
+    }
 }
 
 #[test]
+#[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 fn overflowing_sub_tests() {
     let x0 = 0u128;
     let x1 = 0i128;
@@ -1276,7 +1498,7 @@ fn wrapping_add_ilimb_tests() {
 }
 
 #[test]
-#[cfg(not(feature = "limb32"))]
+#[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 fn wrapping_mul_ulimb_tests() {
     let x = util::to_i256(2, 0).wrapping_mul_ulimb(9223372036854775808);
     assert_eq!(x, util::to_i256(18446744073709551616, 0));
@@ -1298,7 +1520,7 @@ fn checked_rem_tests() {
 }
 
 #[test]
-#[cfg(not(feature = "limb32"))]
+#[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 fn checked_rem_ulimb_tests() {
     // NOTE: With `ulimb` we have to have Python-like handling of the values,
     // rather than how Rust handles remainders.

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -936,6 +936,224 @@ quickcheck! {
             })
         }
     }
+
+    // 32-bit scalars
+
+    fn u256_wrapping_add_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_u32)
+    }
+
+    fn u256_wrapping_sub_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_u32)
+    }
+
+    fn u256_wrapping_mul_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_u32)
+    }
+
+    fn u256_wrapping_div_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_u32)
+        } else {
+            true
+        }
+    }
+
+    fn u256_wrapping_rem_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_u32, |x, y| {
+                x == i256::u256::from(y)
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_overflowing_add_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_u32)
+    }
+
+    fn u256_overflowing_sub_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_u32)
+    }
+
+    fn u256_overflowing_mul_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_u32)
+    }
+
+    fn u256_overflowing_div_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_u32)
+        } else {
+            true
+        }
+    }
+
+    fn u256_overflowing_rem_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_u32, |x: (i256::u256, bool), y: (u32, bool)| {
+                x.0 == i256::u256::from(y.0) && x.1 == y.1
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_checked_add_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_add, checked_add_u32)
+    }
+
+    fn u256_checked_sub_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_u32)
+    }
+
+    fn u256_checked_mul_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_u32)
+    }
+
+    fn u256_checked_div_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(check x0, x1, y, checked_div, checked_div_u32)
+        } else {
+            true
+        }
+    }
+
+    fn u256_checked_rem_u32_quickcheck(x0: u128, x1: u128, y: u32) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_u32, |x: Option<i256::u256>, y: Option<u32>| {
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::u256::from(v).to_le_bytes())
+            })
+        } else {
+            true
+        }
+    }
+
+    fn i256_wrapping_add_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_u32)
+    }
+
+    fn i256_wrapping_sub_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_u32)
+    }
+
+    fn i256_wrapping_mul_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_u32)
+    }
+
+    fn i256_overflowing_add_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_u32)
+    }
+
+    fn i256_overflowing_sub_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_u32)
+    }
+
+    fn i256_overflowing_mul_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_u32)
+    }
+
+    fn i256_checked_add_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_u32)
+    }
+
+    fn i256_checked_sub_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_u32)
+    }
+
+    fn i256_checked_mul_u32_quickcheck(x0: u128, x1: i128, y: u32) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_u32)
+    }
+
+    fn i256_wrapping_add_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_i32)
+    }
+
+    fn i256_wrapping_sub_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_i32)
+    }
+
+    fn i256_wrapping_mul_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_i32)
+    }
+
+    fn i256_wrapping_div_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_i32)
+        }
+    }
+
+    fn i256_wrapping_rem_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_i32, |x, y| {
+                x == i256::i256::from_i32(y)
+            })
+        }
+    }
+
+    fn i256_overflowing_add_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_i32)
+    }
+
+    fn i256_overflowing_sub_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_i32)
+    }
+
+    fn i256_overflowing_mul_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_i32)
+    }
+
+    fn i256_overflowing_div_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_i32)
+        }
+    }
+
+    fn i256_overflowing_rem_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_i32, |x: (i256::i256, bool), y: (i32, bool)| {
+                x.0 == i256::i256::from(y.0) && x.1 == y.1
+            })
+        }
+    }
+
+    fn i256_checked_add_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_i32)
+    }
+
+    fn i256_checked_sub_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_i32)
+    }
+
+    fn i256_checked_mul_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_i32)
+    }
+
+    fn i256_checked_div_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(check x0, x1, y, checked_div, checked_div_i32)
+        }
+    }
+
+    fn i256_checked_rem_i32_quickcheck(x0: u128, x1: i128, y: i32) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_i32, |x: Option<i256::i256>, y: Option<i32>| {
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::i256::from(v).to_le_bytes())
+            })
+        }
+    }
 }
 
 #[test]

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -241,6 +241,10 @@ quickcheck! {
         unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_ulimb)
     }
 
+    fn u256_wrapping_sub_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_uwide)
+    }
+
     fn u256_wrapping_mul_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_ulimb)
     }
@@ -297,6 +301,10 @@ quickcheck! {
         unsigned_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_ulimb)
     }
 
+    fn u256_overflowing_sub_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_uwide)
+    }
+
     fn u256_overflowing_mul_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_ulimb)
     }
@@ -351,6 +359,10 @@ quickcheck! {
 
     fn u256_checked_sub_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_ulimb)
+    }
+
+    fn u256_checked_sub_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_uwide)
     }
 
     fn u256_checked_mul_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
@@ -685,6 +697,10 @@ quickcheck! {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_ulimb)
     }
 
+    fn i256_wrapping_sub_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_uwide)
+    }
+
     fn i256_wrapping_mul_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_ulimb)
     }
@@ -703,6 +719,10 @@ quickcheck! {
 
     fn i256_overflowing_sub_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_ulimb)
+    }
+
+    fn i256_overflowing_sub_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_uwide)
     }
 
     fn i256_overflowing_mul_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
@@ -725,6 +745,10 @@ quickcheck! {
         signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_ulimb)
     }
 
+    fn i256_checked_sub_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_uwide)
+    }
+
     fn i256_checked_mul_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_ulimb)
     }
@@ -743,6 +767,10 @@ quickcheck! {
 
     fn i256_wrapping_sub_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_ilimb)
+    }
+
+    fn i256_wrapping_sub_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_iwide)
     }
 
     fn i256_wrapping_mul_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
@@ -801,6 +829,10 @@ quickcheck! {
         signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_ilimb)
     }
 
+    fn i256_overflowing_sub_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_iwide)
+    }
+
     fn i256_overflowing_mul_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_ilimb)
     }
@@ -855,6 +887,10 @@ quickcheck! {
 
     fn i256_checked_sub_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_ilimb)
+    }
+
+    fn i256_checked_sub_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_iwide)
     }
 
     fn i256_checked_mul_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -256,7 +256,25 @@ quickcheck! {
     fn u256_wrapping_rem_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         if y != 0 {
             unsigned_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_ulimb, |x, y| {
-                x == i256::u256::from_ulimb(y)
+                x == i256::u256::from(y)
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_wrapping_div_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_uwide)
+        } else {
+            true
+        }
+    }
+
+    fn u256_wrapping_rem_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_uwide, |x, y| {
+                x == i256::u256::from(y)
             })
         } else {
             true
@@ -290,7 +308,25 @@ quickcheck! {
     fn u256_overflowing_rem_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         if y != 0 {
             unsigned_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_ulimb, |x: (i256::u256, bool), y: (i256::ULimb, bool)| {
-                x.0 == i256::u256::from_ulimb(y.0) && x.1 == y.1
+                x.0 == i256::u256::from(y.0) && x.1 == y.1
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_overflowing_div_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_uwide)
+        } else {
+            true
+        }
+    }
+
+    fn u256_overflowing_rem_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_uwide, |x: (i256::u256, bool), y: (i256::UWide, bool)| {
+                x.0 == i256::u256::from(y.0) && x.1 == y.1
             })
         } else {
             true
@@ -324,7 +360,25 @@ quickcheck! {
     fn u256_checked_rem_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         if y != 0 {
             unsigned_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_ulimb, |x: Option<i256::u256>, y: Option<i256::ULimb>| {
-                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::u256::from_ulimb(v).to_le_bytes())
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::u256::from(v).to_le_bytes())
+            })
+        } else {
+            true
+        }
+    }
+
+    fn u256_checked_div_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(check x0, x1, y, checked_div, checked_div_uwide)
+        } else {
+            true
+        }
+    }
+
+    fn u256_checked_rem_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        if y != 0 {
+            unsigned_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_uwide, |x: Option<i256::u256>, y: Option<i256::UWide>| {
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::u256::from(v).to_le_bytes())
             })
         } else {
             true
@@ -636,7 +690,6 @@ quickcheck! {
     }
 
     fn i256_overflowing_mul_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
-        // TODO: Failing on (1, 0, 170141183460469231731687303715884105728)
         signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_uwide)
     }
 
@@ -685,7 +738,25 @@ quickcheck! {
             true
         } else {
             signed_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_ilimb, |x, y| {
-                x == i256::i256::from_ilimb(y)
+                x == i256::i256::from(y)
+            })
+        }
+    }
+
+    fn i256_wrapping_div_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_iwide)
+        }
+    }
+
+    fn i256_wrapping_rem_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, wrapping_rem, wrapping_rem_iwide, |x, y| {
+                x == i256::i256::from_iwide(y)
             })
         }
     }
@@ -719,7 +790,25 @@ quickcheck! {
             true
         } else {
             signed_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_ilimb, |x: (i256::i256, bool), y: (i256::ILimb, bool)| {
-                x.0 == i256::i256::from_ilimb(y.0) && x.1 == y.1
+                x.0 == i256::i256::from(y.0) && x.1 == y.1
+            })
+        }
+    }
+
+    fn i256_overflowing_div_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_iwide)
+        }
+    }
+
+    fn i256_overflowing_rem_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, overflowing_rem, overflowing_rem_iwide, |x: (i256::i256, bool), y: (i256::IWide, bool)| {
+                x.0 == i256::i256::from(y.0) && x.1 == y.1
             })
         }
     }
@@ -753,7 +842,25 @@ quickcheck! {
             true
         } else {
             signed_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_ilimb, |x: Option<i256::i256>, y: Option<i256::ILimb>| {
-                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::i256::from_ilimb(v).to_le_bytes())
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::i256::from(v).to_le_bytes())
+            })
+        }
+    }
+
+    fn i256_checked_div_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(check x0, x1, y, checked_div, checked_div_iwide)
+        }
+    }
+
+    fn i256_checked_rem_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
+            true
+        } else {
+            signed_limb_op_equal!(x0, x1, y, checked_rem, checked_rem_iwide, |x: Option<i256::i256>, y: Option<i256::IWide>| {
+                x.map(|v| v.to_le_bytes()) == y.map(|v| i256::i256::from(v).to_le_bytes())
             })
         }
     }

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -241,6 +241,10 @@ quickcheck! {
         unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_ulimb)
     }
 
+    fn u256_wrapping_mul_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_uwide)
+    }
+
     fn u256_wrapping_div_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         if y != 0 {
             unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_div, wrapping_div_ulimb)
@@ -271,6 +275,10 @@ quickcheck! {
         unsigned_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_ulimb)
     }
 
+    fn u256_overflowing_mul_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_uwide)
+    }
+
     fn u256_overflowing_div_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         if y != 0 {
             unsigned_limb_op_equal!(over x0, x1, y, overflowing_div, overflowing_div_ulimb)
@@ -299,6 +307,10 @@ quickcheck! {
 
     fn u256_checked_mul_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_ulimb)
+    }
+
+    fn u256_checked_mul_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_uwide)
     }
 
     fn u256_checked_div_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
@@ -607,6 +619,10 @@ quickcheck! {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_ulimb)
     }
 
+    fn i256_wrapping_mul_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_uwide)
+    }
+
     fn i256_overflowing_add_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_ulimb)
     }
@@ -617,6 +633,11 @@ quickcheck! {
 
     fn i256_overflowing_mul_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_ulimb)
+    }
+
+    fn i256_overflowing_mul_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        // TODO: Failing on (1, 0, 170141183460469231731687303715884105728)
+        signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_uwide)
     }
 
     fn i256_checked_add_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
@@ -631,12 +652,20 @@ quickcheck! {
         signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_ulimb)
     }
 
+    fn i256_checked_mul_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_uwide)
+    }
+
     fn i256_wrapping_add_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_ilimb)
     }
 
     fn i256_wrapping_sub_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_ilimb)
+    }
+
+    fn i256_wrapping_mul_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_mul, wrapping_mul_iwide)
     }
 
     fn i256_wrapping_mul_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
@@ -673,6 +702,10 @@ quickcheck! {
         signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_ilimb)
     }
 
+    fn i256_overflowing_mul_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_mul, overflowing_mul_iwide)
+    }
+
     fn i256_overflowing_div_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         if y == 0 || (y != -1 && x0 == 0 && x1 == i128::MIN) {
             true
@@ -701,6 +734,10 @@ quickcheck! {
 
     fn i256_checked_mul_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_ilimb)
+    }
+
+    fn i256_checked_mul_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_mul, checked_mul_iwide)
     }
 
     fn i256_checked_div_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {

--- a/devel/tests/ops.rs
+++ b/devel/tests/ops.rs
@@ -233,6 +233,10 @@ quickcheck! {
         unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_ulimb)
     }
 
+    fn u256_wrapping_add_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_uwide)
+    }
+
     fn u256_wrapping_sub_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_ulimb)
     }
@@ -285,6 +289,10 @@ quickcheck! {
         unsigned_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_ulimb)
     }
 
+    fn u256_overflowing_add_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_uwide)
+    }
+
     fn u256_overflowing_sub_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_ulimb)
     }
@@ -335,6 +343,10 @@ quickcheck! {
 
     fn u256_checked_add_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
         unsigned_limb_op_equal!(check x0, x1, y, checked_add, checked_add_ulimb)
+    }
+
+    fn u256_checked_add_uwide_quickcheck(x0: u128, x1: u128, y: i256::UWide) -> bool {
+        unsigned_limb_op_equal!(check x0, x1, y, checked_add, checked_add_uwide)
     }
 
     fn u256_checked_sub_ulimb_quickcheck(x0: u128, x1: u128, y: i256::ULimb) -> bool {
@@ -665,6 +677,10 @@ quickcheck! {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_ulimb)
     }
 
+    fn i256_wrapping_add_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_uwide)
+    }
+
     fn i256_wrapping_sub_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_sub, wrapping_sub_ulimb)
     }
@@ -679,6 +695,10 @@ quickcheck! {
 
     fn i256_overflowing_add_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_ulimb)
+    }
+
+    fn i256_overflowing_add_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_uwide)
     }
 
     fn i256_overflowing_sub_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
@@ -697,6 +717,10 @@ quickcheck! {
         signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_ulimb)
     }
 
+    fn i256_checked_add_uwide_quickcheck(x0: u128, x1: i128, y: i256::UWide) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_uwide)
+    }
+
     fn i256_checked_sub_ulimb_quickcheck(x0: u128, x1: i128, y: i256::ULimb) -> bool {
         signed_limb_op_equal!(check x0, x1, y, checked_sub, checked_sub_ulimb)
     }
@@ -711,6 +735,10 @@ quickcheck! {
 
     fn i256_wrapping_add_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_ilimb)
+    }
+
+    fn i256_wrapping_add_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(wrap x0, x1, y, wrapping_add, wrapping_add_iwide)
     }
 
     fn i256_wrapping_sub_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
@@ -765,6 +793,10 @@ quickcheck! {
         signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_ilimb)
     }
 
+    fn i256_overflowing_add_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(over x0, x1, y, overflowing_add, overflowing_add_iwide)
+    }
+
     fn i256_overflowing_sub_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(over x0, x1, y, overflowing_sub, overflowing_sub_ilimb)
     }
@@ -815,6 +847,10 @@ quickcheck! {
 
     fn i256_checked_add_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {
         signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_ilimb)
+    }
+
+    fn i256_checked_add_iwide_quickcheck(x0: u128, x1: i128, y: i256::IWide) -> bool {
+        signed_limb_op_equal!(check x0, x1, y, checked_add, checked_add_iwide)
     }
 
     fn i256_checked_sub_ilimb_quickcheck(x0: u128, x1: i128, y: i256::ILimb) -> bool {

--- a/devel/tests/util.rs
+++ b/devel/tests/util.rs
@@ -258,7 +258,7 @@ macro_rules! signed_op_equal {
 macro_rules! unsigned_limb_op_equal {
     ($x0:ident, $x1:ident, $y:ident, $full:ident, $limb:ident, $cmp:expr) => {{
         let x = util::to_u256($x0, $x1);
-        let fres = x.$full(i256::u256::from_ulimb($y));
+        let fres = x.$full(i256::u256::from($y));
         let lres = x.$limb($y);
 
         $cmp(fres, lres)

--- a/devel/tests/util.rs
+++ b/devel/tests/util.rs
@@ -271,7 +271,6 @@ macro_rules! signed_op_equal {
 macro_rules! unsigned_limb_op_equal {
     ($x0:ident, $x1:ident, $y:ident, $full:ident, $limb:ident, $cmp:expr) => {{
         let x = util::to_u256($x0, $x1);
-        println!("TODO: Remove, {x:#?}, {}, {}, y {}, yi256 {}", $x0, $x1, $y, i256::u256::from($y));
         let fres = x.$full(i256::u256::from($y));
         let lres = x.$limb($y);
 
@@ -305,7 +304,6 @@ macro_rules! unsigned_limb_op_equal {
             $full,
             $limb,
             |x: Option<i256::u256>, y: Option<i256::u256>| {
-                println!("TODO: Remove, {x:#?}, {y:#?}, {}, {}, {}", $x0, $x1, $y);
                 x.map(|v| v.to_le_bytes()) == y.map(|v| v.to_le_bytes())
             }
         )

--- a/devel/tests/util.rs
+++ b/devel/tests/util.rs
@@ -3,6 +3,7 @@
 use std::mem;
 
 pub use bnum::types::{I256 as Bi256, U256 as Bu256};
+pub use i256::ULimb;
 
 pub fn to_ubnum(x: u128, y: u128) -> Bu256 {
     let buf = [x.to_le_bytes(), y.to_le_bytes()];
@@ -19,12 +20,24 @@ pub fn to_ibnum(x: u128, y: i128) -> Bi256 {
 }
 
 pub fn to_u256(x: u128, y: u128) -> i256::u256 {
-    i256::u256::from_le_u64([x as u64, (x >> 64) as u64, y as u64, (y >> 64) as u64])
+    if ULimb::BITS == 64 {
+        i256::u256::from_le_u64([x as u64, (x >> 64) as u64, y as u64, (y >> 64) as u64])
+    } else {
+        i256::u256::from_le_u32([
+            x as u32,
+            (x >> 32) as u32,
+            (x >> 64) as u32,
+            (x >> 96) as u32,
+            y as u32,
+            (y >> 32) as u32,
+            (y >> 64) as u32,
+            (y >> 96) as u32,
+        ])
+    }
 }
 
 pub fn to_i256(x: u128, y: i128) -> i256::i256 {
-    let y = y as u128;
-    i256::i256::from_le_u64([x as u64, (x >> 64) as u64, y as u64, (y >> 64) as u64])
+    to_u256(x, y as u128).as_signed()
 }
 
 macro_rules! unsigned_op_equal {
@@ -258,6 +271,7 @@ macro_rules! signed_op_equal {
 macro_rules! unsigned_limb_op_equal {
     ($x0:ident, $x1:ident, $y:ident, $full:ident, $limb:ident, $cmp:expr) => {{
         let x = util::to_u256($x0, $x1);
+        println!("TODO: Remove, {x:#?}, {}, {}, y {}, yi256 {}", $x0, $x1, $y, i256::u256::from($y));
         let fres = x.$full(i256::u256::from($y));
         let lres = x.$limb($y);
 
@@ -291,6 +305,7 @@ macro_rules! unsigned_limb_op_equal {
             $full,
             $limb,
             |x: Option<i256::u256>, y: Option<i256::u256>| {
+                println!("TODO: Remove, {x:#?}, {y:#?}, {}, {}, {}", $x0, $x1, $y);
                 x.map(|v| v.to_le_bytes()) == y.map(|v| v.to_le_bytes())
             }
         )

--- a/src/int/bitops.rs
+++ b/src/int/bitops.rs
@@ -2,11 +2,19 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::bitops::define!(type => $u_t, wide_type => $wide_t);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::bitops::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         #[inline(always)]
-        #[doc = $crate::shared::bitops::wrapping_shl_doc!($wide_t)]
+        #[doc = $crate::shared::bitops::wrapping_shl_doc!($see_t)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             let result = $crate::math::shift::left_iwide(self.to_ne_wide(), rhs % Self::BITS);
@@ -14,7 +22,7 @@ macro_rules! define {
         }
 
         #[inline(always)]
-        #[doc = $crate::shared::bitops::wrapping_shr_doc!($wide_t)]
+        #[doc = $crate::shared::bitops::wrapping_shr_doc!($see_t)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shr(self, rhs: u32) -> Self {
             let result = $crate::math::shift::right_iwide(self.to_ne_wide(), rhs % Self::BITS);

--- a/src/int/casts.rs
+++ b/src/int/casts.rs
@@ -21,7 +21,7 @@ macro_rules! define {
         /// This produces the same result as an `as` cast, but ensures that the
         /// bit-width remains the same.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, cast_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($wide_t, cast_unsigned)]
         #[inline(always)]
         pub const fn cast_unsigned(self) -> $u_t {
             self.as_unsigned()

--- a/src/int/checked.rs
+++ b/src/int/checked.rs
@@ -2,13 +2,21 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::checked::define!(type => $u_t, wide_type => $wide_t);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::checked::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Checked addition with an unsigned integer. Computes `self + rhs`,
         /// returning `None` if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_add_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_add_unsigned)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_unsigned(self, rhs: $u_t) -> Option<Self> {
@@ -23,7 +31,7 @@ macro_rules! define {
         /// Checked subtraction with an unsigned integer. Computes `self - rhs`,
         /// returning `None` if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_sub_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_sub_unsigned)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_unsigned(self, rhs: $u_t) -> Option<Self> {
@@ -37,7 +45,7 @@ macro_rules! define {
 
         /// Checked negation. Computes `-self`, returning `None` if `self == MIN`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_neg)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_neg(self) -> Option<Self> {
@@ -52,7 +60,7 @@ macro_rules! define {
         /// Checked absolute value. Computes `self.abs()`, returning `None` if
         /// `self == MIN`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_abs)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_abs)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_abs(self) -> Option<Self> {
@@ -72,7 +80,7 @@ macro_rules! define {
         /// `checked_ilog2` can produce results more efficiently for base 2, and
         /// `checked_ilog10` can produce results more efficiently for base 10.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_ilog)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_ilog)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_ilog(self, base: Self) -> Option<u32> {
@@ -109,7 +117,7 @@ macro_rules! define {
         /// multiple of `rhs`. Returns `None` if `rhs` is zero or the operation
         /// would result in overflow.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, checked_next_multiple_of)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_next_multiple_of)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {

--- a/src/int/constants.rs
+++ b/src/int/constants.rs
@@ -4,18 +4,20 @@
 macro_rules! define {
     (
         bits => $bits:expr,
-        wide_type => $wide_t:ty $(,)?
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
     ) => {
         $crate::shared::constants::define!(
             bits => $bits,
             wide_type => $wide_t,
             low_type => $crate::ULimb,
             high_type => $crate::ILimb,
+            see_type => $see_t,
         );
 
         #[deprecated]
         #[inline(always)]
-        #[doc = $crate::shared::constants::min_value_doc!($wide_t)]
+        #[doc = $crate::shared::constants::min_value_doc!($see_t)]
         pub const fn min_value() -> Self {
             let mut limbs = [0; Self::LIMBS];
             ne_index!(limbs[Self::LIMBS - 1] = $crate::ILimb::MIN as $crate::ULimb);
@@ -24,7 +26,7 @@ macro_rules! define {
 
         #[deprecated]
         #[inline(always)]
-        #[doc = $crate::shared::constants::max_value_doc!($wide_t)]
+        #[doc = $crate::shared::constants::max_value_doc!($see_t)]
         pub const fn max_value() -> Self {
             let mut limbs = [$crate::ULimb::MAX; Self::LIMBS];
             ne_index!(limbs[Self::LIMBS - 1] = $crate::ILimb::MAX as $crate::ULimb);

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -365,9 +365,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_uwide(self, n: $crate::UWide) -> Self {
-            todo!();
-            //let limbs = $crate::math::sub::wrapping_uwide(&self.to_ne_limbs(), n);
-            //Self::from_ne_limbs(limbs)
+            let limbs = $crate::math::sub::wrapping_uwide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
         }
 
         /// Subtract [`IWide`][crate::IWide] from the big integer, wrapping on
@@ -377,9 +376,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_iwide(self, n: $crate::IWide) -> Self {
-            todo!();
-            //let limbs = $crate::math::sub::wrapping_iwide(&self.to_ne_limbs(), n);
-            //Self::from_ne_limbs(limbs)
+            let limbs = $crate::math::sub::wrapping_iwide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
         }
 
         /// Multiply our big integer by [`UWide`][crate::UWide], wrapping on overflow.
@@ -626,9 +624,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_uwide(self, n: $crate::UWide) -> (Self, bool) {
-            todo!();
-            //let (limbs, overflowed) = $crate::math::sub::overflowing_uwide(&self.to_ne_limbs(), n);
-            //(Self::from_ne_limbs(limbs), overflowed)
+            let (limbs, overflowed) = $crate::math::sub::overflowing_uwide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
         }
 
         /// Subtract [`IWide`][crate::IWide] from the big integer, returning the value
@@ -638,9 +635,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_iwide(self, n: $crate::IWide) -> (Self, bool) {
-            todo!();
-            //let (limbs, overflowed) = $crate::math::sub::overflowing_iwide(&self.to_ne_limbs(), n);
-            //(Self::from_ne_limbs(limbs), overflowed)
+            let (limbs, overflowed) = $crate::math::sub::overflowing_iwide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
         }
 
         /// Multiply our big integer by [`UWide`][crate::UWide], returning the value

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -176,7 +176,88 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`i32`] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_i32(self, n: i32) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_i32(n)
+            } else {
+                match self.checked_add_i32(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`i32`] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_i32(self, n: i32) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_i32(n)
+            } else {
+                match self.checked_sub_i32(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`i32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_i32(self, n: i32) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_i32(n)
+            } else {
+                match self.checked_mul_i32(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_i32(self, n: i32) -> (Self, i32) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_i32(n)
+            } else {
+                match self.checked_div_rem_i32(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`i32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_i32(self, n: i32) -> Self {
+            self.div_rem_i32(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`i32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_i32(self, n: i32) -> i32 {
+            self.div_rem_i32(n).1
+        }
 
         // U64
 
@@ -468,7 +549,107 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`u32`] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_u32(self, n: u32) -> Self {
+            self.wrapping_add_ulimb(n as $crate::ULimb)
+        }
+
+        /// Add [`i32`] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_i32(self, n: i32) -> Self {
+            self.wrapping_add_ilimb(n as $crate::ILimb)
+        }
+
+        /// Subtract [`u32`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_u32(self, n: u32) -> Self {
+            self.wrapping_sub_ulimb(n as $crate::ULimb)
+        }
+
+        /// Subtract [`i32`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_i32(self, n: i32) -> Self {
+            self.wrapping_sub_ilimb(n as $crate::ILimb)
+        }
+
+        /// Multiply our big integer by [`u32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_u32(self, n: u32) -> Self {
+            self.wrapping_mul_ulimb(n as $crate::ULimb)
+        }
+
+        /// Multiply our big integer by [`i32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_i32(self, n: i32) -> Self {
+            self.wrapping_mul_ilimb(n as $crate::ILimb)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice. This
+        /// has to use the floor division since we can never have a non-
+        /// negative rem.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_u32(self, n: u32) -> (Self, u32) {
+            let (quo, rem) = self.wrapping_div_rem_ulimb(n as $crate::ULimb);
+            (quo, rem as u32)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_i32(self, n: i32) -> (Self, i32) {
+            let (quo, rem) = self.wrapping_div_rem_ilimb(n as $crate::ILimb);
+            (quo, rem as i32)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`i32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_i32(self, n: i32) -> Self {
+            self.wrapping_div_rem_i32(n).0
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`i32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_i32(self, n: i32) -> i32 {
+            self.wrapping_div_rem_i32(n).1
+        }
 
         // U64
 
@@ -706,7 +887,100 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`u32`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_u32(self, n: u32) -> (Self, bool) {
+            self.overflowing_add_ulimb(n as $crate::ULimb)
+        }
+
+        /// Add [`i32`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_i32(self, n: i32) -> (Self, bool) {
+            self.overflowing_add_ilimb(n as $crate::ILimb)
+        }
+
+        /// Subtract [`u32`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_u32(self, n: u32) -> (Self, bool) {
+            self.overflowing_sub_ulimb(n as $crate::ULimb)
+        }
+
+        /// Subtract [`i32`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_i32(self, n: i32) -> (Self, bool) {
+            self.overflowing_sub_ilimb(n as $crate::ILimb)
+        }
+
+        /// Multiply our big integer by [`u32`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_u32(self, n: u32) -> (Self, bool) {
+            self.overflowing_mul_ulimb(n as $crate::ULimb)
+        }
+
+        /// Multiply our big integer by [`i32`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_i32(self, n: i32) -> (Self, bool) {
+            self.overflowing_mul_ilimb(n as $crate::ILimb)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i32`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_rem_i32(self, n: i32) -> ((Self, i32), bool) {
+            let (quorem, overflowed) = self.overflowing_div_rem_ilimb(n as $crate::ILimb);
+            ((quorem.0, quorem.1 as i32), overflowed)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`i32`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_i32(self, n: i32) -> (Self, bool) {
+            self.overflowing_div_ilimb(n as $crate::ILimb)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`i32`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_i32(self, n: i32) -> (i32, bool) {
+            let (quo, rem) = self.overflowing_rem_ilimb(n as $crate::ILimb);
+            (quo as i32, rem)
+        }
 
         // U64
 
@@ -878,7 +1152,63 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`i32`] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_i32(self, n: i32) -> Option<Self> {
+            self.checked_add_ilimb(n as $crate::ILimb)
+        }
+
+        /// Subtract [`i32`] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_i32(self, n: i32) -> Option<Self> {
+            self.checked_sub_ilimb(n as $crate::ILimb)
+        }
+
+        /// Multiply our big integer by [`i32`], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_i32(self, n: i32) -> Option<Self> {
+            self.checked_mul_ilimb(n as $crate::ILimb)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i32`], returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_rem_i32(self, n: i32) -> Option<(Self, i32)> {
+            let (quo, rem) = self.checked_div_rem_ilimb(n as $crate::ILimb)?;
+            Some((quo, rem as i32))
+        }
+
+        /// Get the quotient of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_i32(self, n: i32) -> Option<Self> {
+            Some(self.checked_div_rem_i32(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_i32(self, n: i32) -> Option<i32> {
+            Some(self.checked_div_rem_i32(n)?.1)
+        }
 
         // U64
 

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -344,9 +344,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_uwide(self, n: $crate::UWide) -> Self {
-            todo!();
-            //let limbs = $crate::math::add::wrapping_uwide(&self.to_ne_limbs(), n);
-            //Self::from_ne_limbs(limbs)
+            let limbs = $crate::math::add::wrapping_uwide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
         }
 
         /// Add [`IWide`][crate::IWide] to the big integer, wrapping on overflow.
@@ -355,9 +354,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_iwide(self, n: $crate::IWide) -> Self {
-            todo!();
-            //let limbs = $crate::math::add::wrapping_iwide(&self.to_ne_limbs(), n);
-            //Self::from_ne_limbs(limbs)
+            let limbs = $crate::math::add::wrapping_iwide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
         }
 
         /// Subtract [`UWide`][crate::UWide] from the big integer, wrapping on
@@ -606,9 +604,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_uwide(self, n: $crate::UWide) -> (Self, bool) {
-            todo!();
-            //let (limbs, overflowed) = $crate::math::add::overflowing_uwide(&self.to_ne_limbs(), n);
-            //(Self::from_ne_limbs(limbs), overflowed)
+            let (limbs, overflowed) = $crate::math::add::overflowing_uwide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
         }
 
         /// Add [`IWide`][crate::IWide] to the big integer, returning the value
@@ -618,9 +615,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_iwide(self, n: $crate::IWide) -> (Self, bool) {
-            todo!();
-            //let (limbs, overflowed) = $crate::math::add::overflowing_iwide(&self.to_ne_limbs(), n);
-            //(Self::from_ne_limbs(limbs), overflowed)
+            let (limbs, overflowed) = $crate::math::add::overflowing_iwide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
         }
 
         /// Subtract [`UWide`][crate::UWide] from the big integer, returning the value

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -173,6 +173,10 @@ macro_rules! define {
         pub fn rem_iwide(self, n: $crate::IWide) -> $crate::IWide {
             self.div_rem_iwide(n).1
         }
+    };
+
+    (fixed) => {
+        $crate::shared::limb::define!(fixed);
 
         // U32
 
@@ -546,6 +550,10 @@ macro_rules! define {
         pub fn wrapping_rem_iwide(self, n: $crate::IWide) -> $crate::IWide {
             self.wrapping_div_rem_iwide(n).1
         }
+    };
+
+    (@wrapping-fixed) => {
+        $crate::shared::limb::define!(@wrapping-fixed);
 
         // U32
 
@@ -884,6 +892,10 @@ macro_rules! define {
             let (value, overflowed) = self.overflowing_div_rem_iwide(n);
             (value.1, overflowed)
         }
+    };
+
+    (@overflowing-fixed) => {
+        $crate::shared::limb::define!(@overflowing-fixed);
 
         // U32
 
@@ -1149,6 +1161,10 @@ macro_rules! define {
         pub fn checked_rem_iwide(self, n: $crate::IWide) -> Option<$crate::IWide> {
             Some(self.checked_div_rem_iwide(n)?.1)
         }
+    };
+
+    (@checked-fixed) => {
+        $crate::shared::limb::define!(@checked-fixed);
 
         // U32
 
@@ -1224,6 +1240,15 @@ macro_rules! define {
         $crate::int::limb::define!(@wrapping);
         $crate::int::limb::define!(@overflowing);
         $crate::int::limb::define!(@checked);
+
+        #[cfg(feature = "stdint")]
+        $crate::int::limb::define!(fixed);
+        #[cfg(feature = "stdint")]
+        $crate::int::limb::define!(@wrapping-fixed);
+        #[cfg(feature = "stdint")]
+        $crate::int::limb::define!(@overflowing-fixed);
+        #[cfg(feature = "stdint")]
+        $crate::int::limb::define!(@checked-fixed);
     };
 }
 

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -265,11 +265,173 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`i64`] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_i64(self, n: i64) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_i64(n)
+            } else {
+                match self.checked_add_i64(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`i64`] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_i64(self, n: i64) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_i64(n)
+            } else {
+                match self.checked_sub_i64(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`i64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_i64(self, n: i64) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_i64(n)
+            } else {
+                match self.checked_mul_i64(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_i64(self, n: i64) -> (Self, i64) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_i64(n)
+            } else {
+                match self.checked_div_rem_i64(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`i64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_i64(self, n: i64) -> Self {
+            self.div_rem_i64(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`i64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_i64(self, n: i64) -> i64 {
+            self.div_rem_i64(n).1
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`i128`] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_i128(self, n: i128) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_i128(n)
+            } else {
+                match self.checked_add_i128(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`i128`] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_i128(self, n: i128) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_i128(n)
+            } else {
+                match self.checked_sub_i128(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`i128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_i128(self, n: i128) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_i128(n)
+            } else {
+                match self.checked_mul_i128(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_i128(self, n: i128) -> (Self, i128) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_i128(n)
+            } else {
+                match self.checked_div_rem_i128(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`i128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_i128(self, n: i128) -> Self {
+            self.div_rem_i128(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`i128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_i128(self, n: i128) -> i128 {
+            self.div_rem_i128(n).1
+        }
     };
 
     (@wrapping) => {
@@ -661,11 +823,333 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`u64`] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_u64(self, n: u64) -> Self {
+            let limbs = $crate::math::add::wrapping_uscalar_i64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Add [`i64`] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_i64(self, n: i64) -> Self {
+            let limbs = $crate::math::add::wrapping_iscalar_i64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Subtract [`u64`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_u64(self, n: u64) -> Self {
+            let limbs = $crate::math::sub::wrapping_uscalar_i64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Subtract [`i64`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_i64(self, n: i64) -> Self {
+            let limbs = $crate::math::sub::wrapping_iscalar_i64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Multiply our big integer by [`u64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_u64(self, n: u64) -> Self {
+            let limbs = $crate::math::mul::wrapping_uscalar_i64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Multiply our big integer by [`i64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_i64(self, n: i64) -> Self {
+            let limbs = $crate::math::mul::wrapping_iscalar_i64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice. This
+        /// has to use the floor division since we can never have a non-
+        /// negative rem.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_u64(self, n: u64) -> (Self, u64) {
+            const BITS: u32 = $crate::ULimb::BITS;
+            assert!(BITS == 32 || BITS == 64);
+            if BITS == 32 {
+                let (quo, rem) = self.wrapping_div_rem_uwide(n as $crate::UWide);
+                (quo, rem as u64)
+            } else {
+                let (quo, rem) = self.wrapping_div_rem_ulimb(n as $crate::ULimb);
+                (quo, rem as u64)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_i64(self, n: i64) -> (Self, i64) {
+            const BITS: u32 = $crate::ULimb::BITS;
+            assert!(BITS == 32 || BITS == 64);
+            if BITS == 32 {
+                let (quo, rem) = self.wrapping_div_rem_iwide(n as $crate::IWide);
+                (quo, rem as i64)
+            } else {
+                let (quo, rem) = self.wrapping_div_rem_ilimb(n as $crate::ILimb);
+                (quo, rem as i64)
+            }
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`i64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_i64(self, n: i64) -> Self {
+            self.wrapping_div_rem_i64(n).0
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`i64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_i64(self, n: i64) -> i64 {
+            self.wrapping_div_rem_i64(n).1
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`u128`] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_u128(self, n: u128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_add_uwide(n as $crate::UWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb_n::<{ Self::LIMBS }>(n);
+                let limbs = $crate::math::add::wrapping_mn(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Add [`i128`] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_i128(self, n: i128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_add_iwide(n as $crate::IWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::i128_to_limb_n::<{ Self::LIMBS }>(n);
+                let limbs = $crate::math::add::wrapping_mn(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Subtract [`u128`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_u128(self, n: u128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_sub_uwide(n as $crate::UWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb_n::<{ Self::LIMBS }>(n);
+                let limbs = $crate::math::sub::wrapping_mn(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Subtract [`i128`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_i128(self, n: i128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_sub_iwide(n as $crate::IWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::i128_to_limb_n::<{ Self::LIMBS }>(n);
+                let limbs = $crate::math::sub::wrapping_mn(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Multiply our big integer by [`u128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_u128(self, n: u128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_mul_uwide(n as $crate::UWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb_n::<{ Self::LIMBS }>(n);
+                let limbs = $crate::math::mul::wrapping_signed(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Multiply our big integer by [`i128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_i128(self, n: i128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_mul_iwide(n as $crate::IWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::i128_to_limb_n::<{ Self::LIMBS }>(n);
+                let limbs = $crate::math::mul::wrapping_signed(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice. This
+        /// has to use the floor division since we can never have a non-
+        /// negative rem.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_u128(self, n: u128) -> (Self, u128) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                let (quo, rem) = self.wrapping_div_rem_uwide(n as $crate::UWide);
+                (quo, rem as u128)
+            } else {
+                let x = self.unsigned_abs().to_le_limbs();
+                let (div, mut rem) = $crate::math::div::from_u128(&x, n);
+                let mut div = Self::from_le_limbs(div);
+                if self.is_negative() {
+                    div = div.wrapping_neg();
+                }
+                if self.is_negative() && rem != 0 {
+                    div -= Self::from_u8(1);
+                    rem = n - rem;
+                }
+                (div, rem)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        /// This always wraps, which can never happen in practice.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_i128(self, n: i128) -> (Self, i128) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                let (quo, rem) = self.wrapping_div_rem_iwide(n as $crate::IWide);
+                (quo, rem as i128)
+            } else {
+                let x = self.unsigned_abs().to_le_limbs();
+                let (div, rem) = $crate::math::div::from_u128(&x, n.unsigned_abs());
+                let mut div = Self::from_le_limbs(div);
+                let mut rem = rem as i128;
+
+                if self.is_negative() != n.is_negative() {
+                    div = div.wrapping_neg();
+                }
+                if self.is_negative() {
+                    rem = rem.wrapping_neg();
+                }
+
+                (div, rem)
+            }
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`i128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_i128(self, n: i128) -> Self {
+            self.wrapping_div_rem_i128(n).0
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`i128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_i128(self, n: i128) -> i128 {
+            self.wrapping_div_rem_i128(n).1
+        }
     };
 
     (@overflowing) => {
@@ -996,11 +1480,285 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`u64`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_u64(self, n: u64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::add::overflowing_uscalar_i64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Add [`i64`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_i64(self, n: i64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::add::overflowing_iscalar_i64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Subtract [`u64`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_u64(self, n: u64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::sub::overflowing_uscalar_i64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Subtract [`i64`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_i64(self, n: i64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::sub::overflowing_iscalar_i64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Multiply our big integer by [`u64`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_u64(self, n: u64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::mul::overflowing_uscalar_i64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Multiply our big integer by [`i64`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_i64(self, n: i64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::mul::overflowing_iscalar_i64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i64`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_rem_i64(self, n: i64) -> ((Self, i64), bool) {
+            if self.eq_const(Self::MIN) && n == -1 {
+                ((Self::MIN, 0), true)
+            } else {
+                (self.wrapping_div_rem_i64(n), false)
+            }
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`i64`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_i64(self, n: i64) -> (Self, bool) {
+            let (quorem, overflowed) = self.overflowing_div_rem_i64(n);
+            (quorem.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`i64`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_i64(self, n: i64) -> (i64, bool) {
+            let (quorem, overflowed) = self.overflowing_div_rem_i64(n);
+            (quorem.1, overflowed)
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`u128`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_u128(self, n: u128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_add_uwide(n as $crate::UWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb_n::<{ Self::LIMBS }>(n);
+                let (limbs, overflowed) = $crate::math::add::overflowing_mn(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Add [`i128`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_i128(self, n: i128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_add_iwide(n as $crate::IWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::i128_to_limb_n::<{ Self::LIMBS }>(n);
+                let (limbs, overflowed) = $crate::math::add::overflowing_mn(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Subtract [`u128`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_u128(self, n: u128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_sub_uwide(n as $crate::UWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb_n::<{ Self::LIMBS }>(n);
+                let (limbs, overflowed) = $crate::math::sub::overflowing_mn(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Subtract [`i128`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_i128(self, n: i128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_sub_iwide(n as $crate::IWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::i128_to_limb_n::<{ Self::LIMBS }>(n);
+                let (limbs, overflowed) = $crate::math::sub::overflowing_mn(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Multiply our big integer by [`u128`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_u128(self, n: u128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_mul_uwide(n as $crate::UWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb_n::<{ Self::LIMBS }>(n);
+                let (limbs, overflowed) = $crate::math::mul::overflowing_signed(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Multiply our big integer by [`i128`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_i128(self, n: i128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_mul_iwide(n as $crate::IWide)
+            } else {
+                // NOTE: This needs int expansion for correctness.
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::i128_to_limb_n::<{ Self::LIMBS }>(n);
+                let (limbs, overflowed) = $crate::math::mul::overflowing_signed(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i128`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_rem_i128(self, n: i128) -> ((Self, i128), bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                let (quorem, overflowed) = self.overflowing_div_rem_iwide(n as $crate::IWide);
+                ((quorem.0, quorem.1 as i128), overflowed)
+            } else {
+                if self.eq_const(Self::MIN) && n == -1 {
+                    ((Self::MIN, 0), true)
+                } else {
+                    (self.wrapping_div_rem_i128(n), false)
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`i128`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_i128(self, n: i128) -> (Self, bool) {
+            let (quorem, overflowed) = self.overflowing_div_rem_i128(n);
+            (quorem.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`i128`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_i128(self, n: i128) -> (i128, bool) {
+            let (quorem, overflowed) = self.overflowing_div_rem_i128(n);
+            (quorem.1, overflowed)
+        }
     };
 
     (@checked) => {
@@ -1060,7 +1818,10 @@ macro_rules! define {
             if n == 0 {
                 None
             } else {
-                Some(self.wrapping_div_rem_ilimb(n))
+                match self.overflowing_div_rem_ilimb(n) {
+                    (v, false) => Some(v),
+                    _ => None,
+                }
             }
         }
 
@@ -1138,7 +1899,10 @@ macro_rules! define {
             if n == 0 {
                 None
             } else {
-                Some(self.wrapping_div_rem_iwide(n))
+                match self.overflowing_div_rem_iwide(n) {
+                    (v, false) => Some(v),
+                    _ => None,
+                }
             }
         }
 
@@ -1228,11 +1992,165 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`i64`] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_i64(self, n: i64) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_i64(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`i64`] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_i64(self, n: i64) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_i64(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`i64`], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_i64(self, n: i64) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_i64(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i64`], returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_rem_i64(self, n: i64) -> Option<(Self, i64)> {
+            if n == 0 {
+                None
+            } else {
+                match self.overflowing_div_rem_i64(n) {
+                    (v, false) => Some(v),
+                    _ => None,
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_i64(self, n: i64) -> Option<Self> {
+            Some(self.checked_div_rem_i64(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_i64(self, n: i64) -> Option<i64> {
+            Some(self.checked_div_rem_i64(n)?.1)
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`i128`] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_i128(self, n: i128) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_i128(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`i128`] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_i128(self, n: i128) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_i128(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`i128`], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_i128(self, n: i128) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_i128(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`i128`], returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_rem_i128(self, n: i128) -> Option<(Self, i128)> {
+            if n == 0 {
+                None
+            } else {
+                match self.overflowing_div_rem_i128(n) {
+                    (v, false) => Some(v),
+                    _ => None,
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_i128(self, n: i128) -> Option<Self> {
+            Some(self.checked_div_rem_i128(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_i128(self, n: i128) -> Option<i128> {
+            Some(self.checked_div_rem_i128(n)?.1)
+        }
     };
 
     (@all) => {

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -414,18 +414,17 @@ macro_rules! define {
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_uwide(self, n: $crate::UWide) -> (Self, $crate::UWide) {
-            todo!();
-//            let x = self.unsigned_abs().to_le_limbs();
-//            let (div, mut rem) = $crate::math::div::limb(&x, n);
-//            let mut div = Self::from_le_limbs(div);
-//            if self.is_negative() {
-//                div = div.wrapping_neg();
-//            }
-//            if self.is_negative() && rem != 0 {
-//                div -= Self::from_u8(1);
-//                rem = n - rem;
-//            }
-//            (div, rem)
+            let x = self.unsigned_abs().to_le_limbs();
+            let (div, mut rem) = $crate::math::div::wide(&x, n);
+            let mut div = Self::from_le_limbs(div);
+            if self.is_negative() {
+                div = div.wrapping_neg();
+            }
+            if self.is_negative() && rem != 0 {
+                div -= Self::from_u8(1);
+                rem = n - rem;
+            }
+            (div, rem)
         }
 
         /// Get the quotient and remainder of our big integer divided
@@ -436,20 +435,19 @@ macro_rules! define {
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_iwide(self, n: $crate::IWide) -> (Self, $crate::IWide) {
-            todo!();
-//            let x = self.unsigned_abs().to_le_limbs();
-//            let (div, rem) = $crate::math::div::limb(&x, n.unsigned_abs());
-//            let mut div = Self::from_le_limbs(div);
-//            let mut rem = rem as $crate::IWide;
-//
-//            if self.is_negative() != n.is_negative() {
-//                div = div.wrapping_neg();
-//            }
-//            if self.is_negative() {
-//                rem = rem.wrapping_neg();
-//            }
-//
-//            (div, rem)
+            let x = self.unsigned_abs().to_le_limbs();
+            let (div, rem) = $crate::math::div::wide(&x, n.unsigned_abs());
+            let mut div = Self::from_le_limbs(div);
+            let mut rem = rem as $crate::IWide;
+
+            if self.is_negative() != n.is_negative() {
+                div = div.wrapping_neg();
+            }
+            if self.is_negative() {
+                rem = rem.wrapping_neg();
+            }
+
+            (div, rem)
         }
 
         /// Get the quotient of our big integer divided

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -4,7 +4,9 @@ macro_rules! define {
     () => {
         $crate::shared::limb::define!();
 
-        /// Add a signed limb to the big integer.
+        // LIMB
+
+        /// Add [`ILimb`][crate::ILimb] to the big integer.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -20,7 +22,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract a signed limb from the big integer.
+        /// Subtract [`ILimb`][crate::ILimb] from the big integer.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
@@ -36,7 +38,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by a signed limb.
+        /// Multiply our big integer by [`ILimb`][crate::ILimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
@@ -53,7 +55,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by a signed limb.
+        /// by [`ILimb`][crate::ILimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
@@ -69,7 +71,7 @@ macro_rules! define {
             }
         }
 
-        /// Get the quotient of our big integer divided by a signed limb.
+        /// Get the quotient of our big integer divided by [`ILimb`][crate::ILimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -78,7 +80,7 @@ macro_rules! define {
             self.div_rem_ilimb(n).0
         }
 
-        /// Get the remainder of our big integer divided by a signed limb.
+        /// Get the remainder of our big integer divided by [`ILimb`][crate::ILimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -86,12 +88,111 @@ macro_rules! define {
         pub fn rem_ilimb(self, n: $crate::ILimb) -> $crate::ILimb {
             self.div_rem_ilimb(n).1
         }
+
+        // WIDE
+
+        /// Add [`IWide`][crate::IWide] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_iwide(self, n: $crate::IWide) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_iwide(n)
+            } else {
+                match self.checked_add_iwide(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`IWide`][crate::IWide] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_iwide(self, n: $crate::IWide) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_iwide(n)
+            } else {
+                match self.checked_sub_iwide(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`IWide`][crate::IWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_iwide(self, n: $crate::IWide) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_iwide(n)
+            } else {
+                match self.checked_mul_iwide(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`IWide`][crate::IWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_iwide(self, n: $crate::IWide) -> (Self, $crate::IWide) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_iwide(n)
+            } else {
+                match self.checked_div_rem_iwide(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`IWide`][crate::IWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_iwide(self, n: $crate::IWide) -> Self {
+            self.div_rem_iwide(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`IWide`][crate::IWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_iwide(self, n: $crate::IWide) -> $crate::IWide {
+            self.div_rem_iwide(n).1
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@wrapping) => {
         $crate::shared::limb::define!(@wrapping);
 
-        /// Add an unsigned limb to the big integer, wrapping on overflow.
+        // LIMB
+
+        /// Add [`ULimb`][crate::ULimb] to the big integer, wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -101,7 +202,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Add a signed limb to the big integer, wrapping on overflow.
+        /// Add [`ILimb`][crate::ILimb] to the big integer, wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -111,7 +212,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Subtract an unsigned limb from the big integer, wrapping on
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer, wrapping on
         /// overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
@@ -122,7 +223,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Subtract a signed limb from the big integer, wrapping on
+        /// Subtract [`ILimb`][crate::ILimb] from the big integer, wrapping on
         /// overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
@@ -133,7 +234,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Multiply our big integer by an unsigned limb, wrapping on overflow.
+        /// Multiply our big integer by [`ULimb`][crate::ULimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         /// This in worst case 5 `mul`, 3 `add`, and 6 `sub` instructions,
@@ -148,7 +249,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Multiply our big integer by a signed limb, wrapping on overflow.
+        /// Multiply our big integer by [`ILimb`][crate::ILimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         /// This in worst case 4 `mul`, 3 `add`, and 6 `sub` instructions,
@@ -162,7 +263,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by an unsigned limb, wrapping on overflow.
+        /// by [`ULimb`][crate::ULimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         /// This always wraps, which can never happen in practice. This
@@ -189,7 +290,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by a signed limb, wrapping on overflow.
+        /// by [`ILimb`][crate::ILimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         /// This always wraps, which can never happen in practice.
@@ -216,7 +317,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided
-        /// by a signed limb, wrapping on overflow.
+        /// by [`ILimb`][crate::ILimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -226,7 +327,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided
-        /// by a signed limb, wrapping on overflow.
+        /// by [`ILimb`][crate::ILimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -234,12 +335,162 @@ macro_rules! define {
         pub fn wrapping_rem_ilimb(self, n: $crate::ILimb) -> $crate::ILimb {
             self.wrapping_div_rem_ilimb(n).1
         }
+
+        // WIDE
+
+        /// Add [`UWide`][crate::UWide] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_uwide(self, n: $crate::UWide) -> Self {
+            todo!();
+            //let limbs = $crate::math::add::wrapping_uwide(&self.to_ne_limbs(), n);
+            //Self::from_ne_limbs(limbs)
+        }
+
+        /// Add [`IWide`][crate::IWide] to the big integer, wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_iwide(self, n: $crate::IWide) -> Self {
+            todo!();
+            //let limbs = $crate::math::add::wrapping_iwide(&self.to_ne_limbs(), n);
+            //Self::from_ne_limbs(limbs)
+        }
+
+        /// Subtract [`UWide`][crate::UWide] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_uwide(self, n: $crate::UWide) -> Self {
+            todo!();
+            //let limbs = $crate::math::sub::wrapping_uwide(&self.to_ne_limbs(), n);
+            //Self::from_ne_limbs(limbs)
+        }
+
+        /// Subtract [`IWide`][crate::IWide] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_iwide(self, n: $crate::IWide) -> Self {
+            todo!();
+            //let limbs = $crate::math::sub::wrapping_iwide(&self.to_ne_limbs(), n);
+            //Self::from_ne_limbs(limbs)
+        }
+
+        /// Multiply our big integer by [`UWide`][crate::UWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_uwide(self, n: $crate::UWide) -> Self {
+            let limbs = $crate::math::mul::wrapping_uwide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Multiply our big integer by [`IWide`][crate::IWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_iwide(self, n: $crate::IWide) -> Self {
+            let limbs = $crate::math::mul::wrapping_iwide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`UWide`][crate::UWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        /// This always wraps, which can never happen in practice. This
+        /// has to use the floor division since we can never have a non-
+        /// negative rem.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_uwide(self, n: $crate::UWide) -> (Self, $crate::UWide) {
+            todo!();
+//            let x = self.unsigned_abs().to_le_limbs();
+//            let (div, mut rem) = $crate::math::div::limb(&x, n);
+//            let mut div = Self::from_le_limbs(div);
+//            if self.is_negative() {
+//                div = div.wrapping_neg();
+//            }
+//            if self.is_negative() && rem != 0 {
+//                div -= Self::from_u8(1);
+//                rem = n - rem;
+//            }
+//            (div, rem)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`IWide`][crate::IWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        /// This always wraps, which can never happen in practice.
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_iwide(self, n: $crate::IWide) -> (Self, $crate::IWide) {
+            todo!();
+//            let x = self.unsigned_abs().to_le_limbs();
+//            let (div, rem) = $crate::math::div::limb(&x, n.unsigned_abs());
+//            let mut div = Self::from_le_limbs(div);
+//            let mut rem = rem as $crate::IWide;
+//
+//            if self.is_negative() != n.is_negative() {
+//                div = div.wrapping_neg();
+//            }
+//            if self.is_negative() {
+//                rem = rem.wrapping_neg();
+//            }
+//
+//            (div, rem)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`IWide`][crate::IWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_iwide(self, n: $crate::IWide) -> Self {
+            self.wrapping_div_rem_iwide(n).0
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`IWide`][crate::IWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_iwide(self, n: $crate::IWide) -> $crate::IWide {
+            self.wrapping_div_rem_iwide(n).1
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@overflowing) => {
         $crate::shared::limb::define!(@overflowing);
 
-        /// Add an unsigned limb to the big integer, returning the value
+        // LIMB
+
+        /// Add [`ULimb`][crate::ULimb] to the big integer, returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
@@ -250,7 +501,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Add a signed limb to the big integer, returning the value
+        /// Add [`ILimb`][crate::ILimb] to the big integer, returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
@@ -261,7 +512,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Subtract an unsigned limb from the big integer, returning the value
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer, returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
@@ -272,7 +523,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Subtract a signed limb from the big integer, returning the value
+        /// Subtract [`ILimb`][crate::ILimb] from the big integer, returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
@@ -283,7 +534,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Multiply our big integer by an unsigned limb, returning the value
+        /// Multiply our big integer by [`ULimb`][crate::ULimb], returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
@@ -296,7 +547,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Multiply our big integer by a signed limb, returning the value
+        /// Multiply our big integer by [`ILimb`][crate::ILimb], returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
@@ -310,7 +561,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by a signed limb, returning the value and if overflow
+        /// by [`ILimb`][crate::ILimb], returning the value and if overflow
         /// occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -325,7 +576,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided
-        /// by a signed limb, returning the value and if overflow
+        /// by [`ILimb`][crate::ILimb], returning the value and if overflow
         /// occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -337,7 +588,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided
-        /// by a signed limb, returning the value and if overflow
+        /// by [`ILimb`][crate::ILimb], returning the value and if overflow
         /// occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -347,12 +598,141 @@ macro_rules! define {
             let (value, overflowed) = self.overflowing_div_rem_ilimb(n);
             (value.1, overflowed)
         }
+
+        // WIDE
+
+        /// Add [`UWide`][crate::UWide] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            todo!();
+            //let (limbs, overflowed) = $crate::math::add::overflowing_uwide(&self.to_ne_limbs(), n);
+            //(Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Add [`IWide`][crate::IWide] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_iwide(self, n: $crate::IWide) -> (Self, bool) {
+            todo!();
+            //let (limbs, overflowed) = $crate::math::add::overflowing_iwide(&self.to_ne_limbs(), n);
+            //(Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Subtract [`UWide`][crate::UWide] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            todo!();
+            //let (limbs, overflowed) = $crate::math::sub::overflowing_uwide(&self.to_ne_limbs(), n);
+            //(Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Subtract [`IWide`][crate::IWide] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_iwide(self, n: $crate::IWide) -> (Self, bool) {
+            todo!();
+            //let (limbs, overflowed) = $crate::math::sub::overflowing_iwide(&self.to_ne_limbs(), n);
+            //(Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Multiply our big integer by [`UWide`][crate::UWide], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        /// This in worst case 4 `mul`, 4 `add`, and 6 `sub` instructions,
+        /// significantly slower than the wrapping variant.
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::mul::overflowing_uwide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Multiply our big integer by [`IWide`][crate::IWide], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        /// This in worst case 5 `mul`, 5 `add`, and 6 `sub` instructions,
+        /// significantly slower than the wrapping variant.
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_iwide(self, n: $crate::IWide) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::mul::overflowing_iwide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`IWide`][crate::IWide], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_rem_iwide(self, n: $crate::IWide) -> ((Self, $crate::IWide), bool) {
+            if self.eq_const(Self::MIN) && n == -1 {
+                ((Self::MIN, 0), true)
+            } else {
+                (self.wrapping_div_rem_iwide(n), false)
+            }
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`IWide`][crate::IWide], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_iwide(self, n: $crate::IWide) -> (Self, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_iwide(n);
+            (value.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`IWide`][crate::IWide], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_iwide(self, n: $crate::IWide) -> ($crate::IWide, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_iwide(n);
+            (value.1, overflowed)
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@checked) => {
         $crate::shared::limb::define!(@checked);
 
-        /// Add a signed limb to the big integer, returning None on overflow.
+        // LIMB
+
+        /// Add [`ILimb`][crate::ILimb] to the big integer, returning None on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -366,7 +746,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract a signed limb from the big integer, returning None on overflow.
+        /// Subtract [`ILimb`][crate::ILimb] from the big integer, returning None on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
@@ -380,7 +760,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by a signed limb, returning None on overflow.
+        /// Multiply our big integer by [`ILimb`][crate::ILimb], returning None on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
@@ -395,7 +775,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by a signed limb, returning None on overflow or division by 0.
+        /// by [`ILimb`][crate::ILimb], returning None on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
@@ -427,6 +807,96 @@ macro_rules! define {
         pub fn checked_rem_ilimb(self, n: $crate::ILimb) -> Option<$crate::ILimb> {
             Some(self.checked_div_rem_ilimb(n)?.1)
         }
+
+        // WIDE
+
+        /// Add [`IWide`][crate::IWide] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_iwide(self, n: $crate::IWide) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_iwide(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`IWide`][crate::IWide] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_iwide(self, n: $crate::IWide) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_iwide(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`IWide`][crate::IWide], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_iwide(self, n: $crate::IWide) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_iwide(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`IWide`][crate::IWide], returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_rem_iwide(self, n: $crate::IWide) -> Option<(Self, $crate::IWide)> {
+            if n == 0 {
+                None
+            } else {
+                Some(self.wrapping_div_rem_iwide(n))
+            }
+        }
+
+        /// Get the quotient of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_iwide(self, n: $crate::IWide) -> Option<Self> {
+            Some(self.checked_div_rem_iwide(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_iwide(self, n: $crate::IWide) -> Option<$crate::IWide> {
+            Some(self.checked_div_rem_iwide(n)?.1)
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@all) => {

--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -40,8 +40,6 @@ pub(crate) mod wrapping;
 /// crate::int::define!(
 ///     name => i256,
 ///     unsigned_t => crate::u256,
-///     unsigned_wide_t => u128,
-///     signed_wide_t => i128,
 ///     bits => 256,
 /// );
 /// ```
@@ -49,8 +47,6 @@ macro_rules! define {
     (
         name => $name:ident,
         unsigned_t => $u_t:ty,
-        unsigned_wide_t => $wide_u_t:ty,
-        signed_wide_t => $wide_s_t:ty,
         bits => $bits:expr  $(,)?
     ) => {
         $crate::shared::int_struct_define!(
@@ -62,30 +58,75 @@ macro_rules! define {
         impl $name {
             $crate::int::constants::define!(
                 bits => $bits,
-                wide_type => $wide_s_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
             );
-            $crate::int::bitops::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::shared::endian::define!(type => $u_t, wide_type => $wide_s_t);
+            $crate::int::bitops::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::shared::endian::define!(
+                type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
             $crate::shared::ord::define!(
-                low_type => $wide_u_t,
-                high_type => $wide_s_t,
+                low_type => $crate::UWide,
+                high_type => $crate::IWide,
             );
             $crate::int::casts::define!(
                 unsigned_type => $u_t,
                 bits => $bits,
-                wide_type => $wide_s_t,
+                wide_type => $crate::IWide,
                 kind => signed,
             );
-            $crate::shared::extensions::define!(high_type => $crate::ILimb);
-            $crate::int::ops::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::shared::bigint::define!(wide_type => $wide_s_t);
-            $crate::int::wrapping::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::int::overflowing::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::int::saturating::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::int::checked::define!(unsigned_type => $u_t, wide_type => $wide_s_t);
-            $crate::int::strict::define!(unsigned_type => $u_t);
-            $crate::int::unchecked::define!(unsigned_type => $u_t);
-            $crate::shared::unbounded::define!(type => $u_t, wide_type => $wide_s_t);
+            $crate::shared::extensions::define!(
+                high_type => $crate::ILimb,
+            );
+            $crate::int::ops::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::shared::bigint::define!(
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::int::wrapping::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::int::overflowing::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::int::saturating::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::int::checked::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::int::strict::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::int::unchecked::define!(
+                unsigned_type => $u_t,
+                wide_type => $crate::IWide,
+                see_type => i64,
+            );
+            $crate::shared::unbounded::define!(
+                type => $u_t,
+                wide_type => $crate::IWide,
+            );
             $crate::int::limb::define!(@all);
 
             $crate::parse::define!(true);

--- a/src/int/ops.rs
+++ b/src/int/ops.rs
@@ -2,7 +2,11 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         #[inline(always)]
         const fn is_div_overflow(self, rhs: Self) -> bool {
             self.eq_const(Self::MIN) & rhs.eq_const(Self::from_i8(-1))
@@ -17,7 +21,7 @@ macro_rules! define {
         /// Returns `true` if `self` is positive and `false` if the number is zero
         /// or negative.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::is_positive`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, is_positive)]
         #[inline(always)]
         pub const fn is_positive(self) -> bool {
             // NOTE: This seems to optimize slightly better than the wide-based one.
@@ -41,7 +45,7 @@ macro_rules! define {
         /// Returns `true` if `self` is negative and `false` if the number is zero
         /// or positive.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::is_negative`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, is_negative)]
         #[inline(always)]
         pub const fn is_negative(self) -> bool {
             // NOTE: Because this is 2's complement, we can optimize like this.
@@ -49,12 +53,16 @@ macro_rules! define {
             high < 0
         }
 
-        $crate::shared::ops::define!(type => $u_t, wide_type => $wide_t);
+        $crate::shared::ops::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Computes the absolute value of `self` without any wrapping
         /// or panicking.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::unsigned_abs`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unsigned_abs)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn unsigned_abs(self) -> $u_t {
@@ -76,7 +84,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::div_euclid`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, div_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_euclid(self, rhs: Self) -> Self {
@@ -98,7 +106,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, rem_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_euclid(self, rhs: Self) -> Self {
@@ -117,7 +125,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, div_floor)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, div_floor)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_floor(self, rhs: Self) -> Self {
@@ -142,7 +150,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_signed_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, div_ceil)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, div_ceil)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_ceil(self, rhs: Self) -> Self {
@@ -167,7 +175,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::overflow_assertions_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, next_multiple_of)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, next_multiple_of)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn next_multiple_of(self, rhs: Self) -> Self {
@@ -218,7 +226,7 @@ macro_rules! define {
         /// This function will panic if `self` is less than or equal to zero,
         /// or if `base` is less than 2.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, ilog)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, ilog)]
         #[inline(always)]
         pub fn ilog(self, base: Self) -> u32 {
             assert!(
@@ -238,7 +246,7 @@ macro_rules! define {
         ///
         /// This function will panic if `self` is less than or equal to zero.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, ilog2)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, ilog2)]
         #[inline(always)]
         pub const fn ilog2(self) -> u32 {
             if let Some(log) = self.checked_ilog2() {
@@ -265,7 +273,7 @@ macro_rules! define {
 
         /// Computes the absolute value of `self`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, abs)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, abs)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn abs(self) -> Self {
@@ -280,7 +288,7 @@ macro_rules! define {
         /// This function always returns the correct answer without overflow or
         /// panics by returning an unsigned integer.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, abs_diff)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, abs_diff)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn abs_diff(self, other: Self) -> $u_t {
@@ -297,7 +305,7 @@ macro_rules! define {
         ///  - `1` if the number is positive
         ///  - `-1` if the number is negative
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, signum)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, signum)]
         #[inline(always)]
         pub const fn signum(self) -> Self {
             match self.cmp_const(Self::from_u8(0)) {
@@ -314,7 +322,7 @@ macro_rules! define {
         /// result is always rounded towards negative infinity and that no
         /// overflow will ever occur.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, midpoint)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, midpoint)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn midpoint(self, rhs: Self) -> Self {

--- a/src/int/overflowing.rs
+++ b/src/int/overflowing.rs
@@ -2,8 +2,16 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::overflowing::define!(type => $u_t, wide_type => $wide_t);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::overflowing::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t
+        );
 
         /// Calculates `self` + `rhs`.
         ///
@@ -11,7 +19,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would have
         /// occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_add)]
         #[inline(always)]
         pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
@@ -26,7 +34,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_sub)]
         #[inline(always)]
         pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
@@ -41,7 +49,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_add_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_add_unsigned)]
         #[inline(always)]
         pub const fn overflowing_add_unsigned(self, rhs: $u_t) -> (Self, bool) {
             let rhs = rhs.as_signed();
@@ -55,7 +63,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_sub_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_sub_unsigned)]
         #[inline(always)]
         pub const fn overflowing_sub_unsigned(self, rhs: $u_t) -> (Self, bool) {
             let rhs = rhs.as_signed();
@@ -72,7 +80,7 @@ macro_rules! define {
         /// This in worst case 10 `mul`, 20 `add`, and 9 `sub` instructions,
         /// significantly slower than the wrapping variant.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_mul)]
         #[inline(always)]
         pub const fn overflowing_mul(self, rhs: Self) -> (Self, bool) {
             let lhs = self.to_ne_limbs();
@@ -89,7 +97,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_div)]
         #[inline(always)]
         pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -107,7 +115,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_div_euclid)]
         #[inline(always)]
         pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -125,7 +133,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_rem)]
         #[inline(always)]
         pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -143,7 +151,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_rem_euclid)]
         #[inline(always)]
         pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {
             if self.is_div_overflow(rhs) {
@@ -161,7 +169,7 @@ macro_rules! define {
         /// minimum value will be returned again and `true` will be returned for an
         /// overflow happening.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_neg)]
         #[inline(always)]
         pub const fn overflowing_neg(self) -> (Self, bool) {
             if self.eq_const(Self::MIN) {
@@ -179,7 +187,7 @@ macro_rules! define {
         /// masked (N-1) where N is the number of bits, and this value is then used
         /// to perform the shift.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_shl)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_shl)]
         #[inline(always)]
         pub const fn overflowing_shl(self, rhs: u32) -> (Self, bool) {
             (self.wrapping_shl(rhs), rhs >= Self::BITS)
@@ -193,7 +201,7 @@ macro_rules! define {
         /// masked (N-1) where N is the number of bits, and this value is then used
         /// to perform the shift.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_shr)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_shr)]
         #[inline(always)]
         pub const fn overflowing_shr(self, rhs: u32) -> (Self, bool) {
             (self.wrapping_shr(rhs), rhs >= Self::BITS)
@@ -204,7 +212,7 @@ macro_rules! define {
         /// Returns a tuple of the absolute version of self along with a boolean
         /// indicating whether an overflow happened.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, overflowing_abs)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_abs)]
         #[inline(always)]
         pub const fn overflowing_abs(self) -> (Self, bool) {
             match self.is_negative() {

--- a/src/int/saturating.rs
+++ b/src/int/saturating.rs
@@ -2,13 +2,21 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::saturating::define!(type => $u_t, wide_type => $wide_t);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::saturating::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Saturating integer addition. Computes `self + rhs`, saturating at the
         /// numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_add)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add(self, rhs: Self) -> Self {
@@ -22,7 +30,7 @@ macro_rules! define {
         /// Saturating addition with an unsigned integer. Computes `self + rhs`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_add_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_add_unsigned)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add_unsigned(self, rhs: $u_t) -> Self {
@@ -37,7 +45,7 @@ macro_rules! define {
         /// Saturating integer subtraction. Computes `self - rhs`, saturating at the
         /// numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_sub)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_sub(self, rhs: Self) -> Self {
@@ -51,7 +59,7 @@ macro_rules! define {
         /// Saturating subtraction with an unsigned integer. Computes `self - rhs`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_sub_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_sub_unsigned)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_sub_unsigned(self, rhs: $u_t) -> Self {
@@ -66,7 +74,7 @@ macro_rules! define {
         /// Saturating integer negation. Computes `-self`, returning `MAX` if `self
         /// == MIN` instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_neg)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_neg(self) -> Self {
@@ -76,7 +84,7 @@ macro_rules! define {
         /// Saturating absolute value. Computes `self.abs()`, returning `MAX` if
         /// `self == MIN` instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_abs)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_abs)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_abs(self) -> Self {
@@ -89,7 +97,7 @@ macro_rules! define {
         /// Saturating integer multiplication. Computes `self * rhs`, saturating at
         /// the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_mul)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_mul(self, rhs: Self) -> Self {
@@ -110,7 +118,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_div)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         #[inline(always)]
         pub fn saturating_div(self, rhs: Self) -> Self {
@@ -123,7 +131,7 @@ macro_rules! define {
         /// Saturating integer exponentiation. Computes `self.pow(exp)`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, saturating_pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_pow)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_pow(self, exp: u32) -> Self {

--- a/src/int/strict.rs
+++ b/src/int/strict.rs
@@ -2,15 +2,23 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty) => {
-        $crate::shared::strict::define!(type => $u_t, wide_type => i128);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::strict::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Strict addition with an unsigned integer. Computes `self + rhs`,
         /// panicking if overflow occurred.
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_add_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_add_unsigned)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -26,7 +34,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_sub_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_sub_unsigned)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -46,7 +54,7 @@ macro_rules! define {
         /// / -1` on a signed type (where `MIN` is the negative minimal value
         /// for the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_div)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -66,7 +74,7 @@ macro_rules! define {
         /// on a signed type (where `MIN` is the negative minimal value), which
         /// is invalid due to implementation artifacts.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_rem)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -87,7 +95,7 @@ macro_rules! define {
         /// for the type); this is equivalent to `-MIN`, a positive value
         /// that is too large to represent in the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_div_euclid)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -107,7 +115,7 @@ macro_rules! define {
         /// on a signed type (where `MIN` is the negative minimal value), which
         /// is invalid due to implementation artifacts.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_rem_euclid)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -122,7 +130,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_neg)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -138,7 +146,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, strict_abs)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_abs)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]

--- a/src/int/traits.rs
+++ b/src/int/traits.rs
@@ -1,7 +1,10 @@
 //! Helpers and logic for working with traits.
 
 macro_rules! define {
-    (type => $t:ident,unsigned_type => $u_t:ty) => {
+    (
+        type => $t:ident,
+        unsigned_type => $u_t:ty $(,)?
+    ) => {
         $crate::shared::traits::define!(impl => $t);
         $crate::shared::shift::define! { big => $t, impl => $u_t }
         $crate::shared::shift::define! { reference => $t, impl => $u_t }

--- a/src/int/unchecked.rs
+++ b/src/int/unchecked.rs
@@ -5,14 +5,22 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty) => {
-        $crate::shared::unchecked::define!(type => $u_t, wide_type => i128);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::unchecked::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Unchecked negation. Computes `-self`, assuming overflow cannot occur.
         ///
         #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, unchecked_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unchecked_neg)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]

--- a/src/int/wrapping.rs
+++ b/src/int/wrapping.rs
@@ -2,13 +2,21 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (unsigned_type => $u_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::wrapping::define!(type => $u_t, wide_type => $wide_t);
+    (
+        unsigned_type => $u_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::wrapping::define!(
+            type => $u_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Wrapping (modular) addition. Computes `self + rhs`, wrapping around at
         /// the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_add)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add(self, rhs: Self) -> Self {
@@ -19,7 +27,7 @@ macro_rules! define {
         /// Wrapping (modular) subtraction. Computes `self - rhs`, wrapping around
         /// at the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_sub)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub(self, rhs: Self) -> Self {
@@ -30,7 +38,7 @@ macro_rules! define {
         /// Wrapping (modular) subtraction with an unsigned integer. Computes
         /// `self - rhs`, wrapping around at the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_sub_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_sub_unsigned)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_unsigned(self, rhs: $u_t) -> Self {
@@ -45,7 +53,7 @@ macro_rules! define {
         /// optimizes nicely for small multiplications. See [`u256::wrapping_mul`]
         /// for a more detailed analysis, which is identical.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_mul)]
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         #[inline(always)]
@@ -103,7 +111,7 @@ macro_rules! define {
         ///
         /// This function will panic if `rhs` is zero.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_div)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div(self, rhs: Self) -> Self {
@@ -122,7 +130,7 @@ macro_rules! define {
         ///
         /// This function will panic if `rhs` is zero.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_div_euclid)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
@@ -149,7 +157,7 @@ macro_rules! define {
         ///
         /// This function will panic if `rhs` is zero.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_rem)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem(self, rhs: Self) -> Self {
@@ -163,7 +171,7 @@ macro_rules! define {
         /// the negative minimal value for the type). In this case, this method
         /// returns 0.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_rem_euclid)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
@@ -191,7 +199,7 @@ macro_rules! define {
         /// type); this is a positive value that is too large to represent
         /// in the type. In such a case, this function returns `MIN` itself.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_neg)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_neg(self) -> Self {
@@ -210,7 +218,7 @@ macro_rules! define {
         /// positive value that is too large to represent in the type. In such a
         /// case, this function returns `MIN` itself.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(i128, wrapping_abs)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_abs)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_abs(self) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,6 @@ pub use types::{ILimb, IWide, ULimb, UWide};
 /// crate::define!(
 ///     unsigned => u256,
 ///     signed => i256,
-///     unsigned_wide => u128,
-///     signed_wide => i128,
 ///     bits => 256,
 /// );
 /// ```
@@ -129,22 +127,16 @@ macro_rules! define {
     (
         unsigned => $unsigned:ident,
         signed => $signed:ident,
-        unsigned_wide => $unsigned_wide:ty,
-        signed_wide => $signed_wide:ty,
         bits => $bits:literal,
     ) => {
         crate::int::define!(
             name => $signed,
             unsigned_t => $unsigned,
-            unsigned_wide_t => $unsigned_wide,
-            signed_wide_t => $signed_wide,
             bits => $bits,
         );
         crate::uint::define!(
             name => $unsigned,
             signed_t => $signed,
-            signed_wide_t => $signed_wide,
-            unsigned_wide_t => $unsigned_wide,
             bits => $bits,
         );
     };
@@ -153,32 +145,24 @@ macro_rules! define {
 define!(
     unsigned => U256,
     signed => I256,
-    unsigned_wide => u128,
-    signed_wide => i128,
     bits => 256,
 );
 #[cfg(feature = "i384")]
 define!(
     unsigned => U384,
     signed => I384,
-    unsigned_wide => u128,
-    signed_wide => i128,
     bits => 384,
 );
 #[cfg(feature = "i512")]
 define!(
     unsigned => U512,
     signed => I512,
-    unsigned_wide => u128,
-    signed_wide => i128,
     bits => 512,
 );
 #[cfg(feature = "i1024")]
 define!(
     unsigned => U1024,
     signed => I1024,
-    unsigned_wide => u128,
-    signed_wide => i128,
     bits => 1024,
 );
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,11 @@
 #![cfg_attr(not(feature = "i512"), doc = "- `i512`: Add the 512-bit `I512` and `U512` types.")]
 #![cfg_attr(feature = "i1024", doc = "- `i1024`: Add the 1024-bit [`I1024`] and [`U1024`] types.")]
 #![cfg_attr(not(feature = "i1024"), doc = "- `i1024`: Add the 1024-bit `I1024` and `U1024` types.")]
+//! - `stdint`: Support operations with fixed-width integer types. The [`ULimb`],
+//! [`UWide`], and other scalars defined may vary in size for optimal performance
+//! on the target architecture (64-bit multiplies, for example, are more expensive
+//! on 32-bit architectures): enabling this API adds in overloads for [`u32`],
+//! [`u64`], and [`u128`], guaranteeing API stability across all platforms.
 //!
 //! If you need larger integers, [`crypto-bigint`] has high-performance
 //! addition, subtraction, and multiplication. With integers with a large

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,11 +22,13 @@
 #![cfg_attr(not(feature = "i512"), doc = "- `i512`: Add the 512-bit `I512` and `U512` types.")]
 #![cfg_attr(feature = "i1024", doc = "- `i1024`: Add the 1024-bit [`I1024`] and [`U1024`] types.")]
 #![cfg_attr(not(feature = "i1024"), doc = "- `i1024`: Add the 1024-bit `I1024` and `U1024` types.")]
-//! - `stdint`: Support operations with fixed-width integer types. The [`ULimb`],
-//! [`UWide`], and other scalars defined may vary in size for optimal performance
-//! on the target architecture (64-bit multiplies, for example, are more expensive
-//! on 32-bit architectures): enabling this API adds in overloads for [`u32`],
-//! [`u64`], and [`u128`], guaranteeing API stability across all platforms.
+//! - `stdint`: Support operations with fixed-width integer types. The
+//!   [`ULimb`],
+//! [`UWide`], and other scalars defined may vary in size for optimal
+//! performance on the target architecture (64-bit multiplies, for example, are
+//! more expensive on 32-bit architectures): enabling this API adds in overloads
+//! for [`u32`], [`u64`], and [`u128`], guaranteeing API stability across all
+//! platforms.
 //!
 //! If you need larger integers, [`crypto-bigint`] has high-performance
 //! addition, subtraction, and multiplication. With integers with a large

--- a/src/math/add.rs
+++ b/src/math/add.rs
@@ -46,6 +46,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_full<const N: usize>(x: &[$u; N], y: &[$u; N]) -> [$u; N] {
             let mut index = 0;
             let mut result = [0; N];
@@ -92,6 +93,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_full<const N: usize>(
             x: &[$u; N],
             y: &[$u; N],
@@ -136,6 +138,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_limb<const N: usize>(x: &[$u; N], y: $u) -> [$u; N] {
             assert!(N >= 2);
 
@@ -185,6 +188,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_limb<const N: usize>(x: &[$u; N], y: $u) -> ([$u; N], bool) {
             assert!(N >= 2);
 
@@ -205,6 +209,7 @@ macro_rules! unsigned_define {
         /// Const implementation of `wrapping_add` for internal algorithm use.
         // NOTE: This differs significantly from `wrapping_full`.
         #[inline]
+        #[must_use]
         pub const fn $wrapping_mn<const M: usize, const N: usize>(
             x: &[$u; M],
             y: &[$u; N],
@@ -235,6 +240,7 @@ macro_rules! unsigned_define {
         /// Const implementation of `overflowing_add` for internal algorithm use.
         // NOTE: This differs significantly from `overflowing_full`.
         #[inline]
+        #[must_use]
         pub const fn $overflowing_mn<const M: usize, const N: usize>(
             x: &[$u; M],
             y: &[$u; N],
@@ -263,6 +269,7 @@ macro_rules! unsigned_define {
 
         /// Const implementation of `wrapping_add` a small number to the wider type.
         #[inline]
+        #[must_use]
         pub const fn $wrapping_wide<const N: usize>(x: &[$u; N], y: $w) -> [$u; N] {
             let mut rhs = [0; 2];
             ne_index!(rhs[0] = y as $u);
@@ -272,6 +279,7 @@ macro_rules! unsigned_define {
 
         /// Const implementation of `overflowing_add` a small number to the wider type.
         #[inline]
+        #[must_use]
         pub const fn $overflowing_wide<const N: usize>(x: &[$u; N], y: $w) -> ([$u; N], bool) {
             let mut rhs = [0; 2];
             ne_index!(rhs[0] = y as $u);
@@ -374,6 +382,7 @@ macro_rules! signed_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_full<const N: usize>(x: &[$u; N], y: &[$u; N]) -> [$u; N] {
             assert!(<$u>::BITS == <$s>::BITS);
             assert!(N >= 2);
@@ -431,6 +440,7 @@ macro_rules! signed_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_full<const N: usize>(
             x: &[$u; N],
             y: &[$u; N],
@@ -497,6 +507,7 @@ macro_rules! signed_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_ulimb<const N: usize>(x: &[$u; N], y: $u) -> [$u; N] {
             assert!(N >= 2);
             assert!(<$u>::BITS == <$s>::BITS);
@@ -547,6 +558,7 @@ macro_rules! signed_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_ulimb<const N: usize>(x: &[$u; N], y: $u) -> ([$u; N], bool) {
             assert!(N >= 2);
             assert!(<$u>::BITS == <$s>::BITS);
@@ -599,6 +611,7 @@ macro_rules! signed_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_ilimb<const N: usize>(x: &[$u; N], y: $s) -> [$u; N] {
             // NOTE: We just want to set it as the low bits of `y` and the single high bit.
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
@@ -642,6 +655,7 @@ macro_rules! signed_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_ilimb<const N: usize>(x: &[$u; N], y: $s) -> ([$u; N], bool) {
             // NOTE: We just want to set it as the low bits of `y` and the single high bit.
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
@@ -651,6 +665,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to add a small, unsigned number to the wider type.
+        #[inline]
+        #[must_use]
         pub const fn $wrapping_uwide<const N: usize>(x: &[$u; N], y: $uw) -> [$u; N] {
             let mut rhs = [0; N];
             ne_index!(rhs[0] = y as $u);
@@ -659,6 +675,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to add a small, unsigned number to the wider type.
+        #[inline]
+        #[must_use]
         pub const fn $overflowing_uwide<const N: usize>(x: &[$u; N], y: $uw) -> ([$u; N], bool) {
             let mut rhs = [0; N];
             ne_index!(rhs[0] = y as $u);
@@ -667,6 +685,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to add a small, signed number to the wider type.
+        #[inline]
+        #[must_use]
         pub const fn $wrapping_iwide<const N: usize>(x: &[$u; N], y: $sw) -> [$u; N] {
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
             let mut rhs = [sign_bit; N];
@@ -677,6 +697,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to add a small, signed number to the wider type.
+        #[inline]
+        #[must_use]
         pub const fn $overflowing_iwide<const N: usize>(x: &[$u; N], y: $sw) -> ([$u; N], bool) {
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
             let mut rhs = [sign_bit; N];

--- a/src/math/add.rs
+++ b/src/math/add.rs
@@ -319,6 +319,14 @@ limb_function!(overflowing_limb, overflowing_limb_u64, overflowing_limb_u32, &[U
 limb_function!(wrapping_wide, wrapping_wide_u64, wrapping_wide_u32, &[ULimb; N], UWide, ret => [ULimb; N]);
 limb_function!(overflowing_wide, overflowing_wide_u64, overflowing_wide_u32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
 
+// u64
+limb_function!(wrapping_scalar_u64, wrapping_limb_u64, wrapping_wide_u32, &[ULimb; N], u64, ret => [ULimb; N]);
+limb_function!(overflowing_scalar_u64, overflowing_limb_u64, overflowing_wide_u32, &[ULimb; N], u64, ret => ([ULimb; N], bool));
+
+// u128
+limb_function!(mn wrapping_mn, wrapping_mn_u64, wrapping_mn_u32, &[ULimb; M], &[ULimb; N], ret => [ULimb; M]);
+limb_function!(mn overflowing_mn, overflowing_mn_u64, overflowing_mn_u32, &[ULimb; M], &[ULimb; N], ret => ([ULimb; M], bool));
+
 macro_rules! signed_define {
     (
         unsigned =>
@@ -729,6 +737,12 @@ limb_function!(wrapping_uwide, wrapping_uwide_i64, wrapping_uwide_i32, &[ULimb; 
 limb_function!(wrapping_iwide, wrapping_iwide_i64, wrapping_iwide_i32, &[ULimb; N], IWide, ret => [ULimb; N]);
 limb_function!(overflowing_uwide, overflowing_uwide_i64, overflowing_uwide_i32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
 limb_function!(overflowing_iwide, overflowing_iwide_i64, overflowing_iwide_i32, &[ULimb; N], IWide, ret => ([ULimb; N], bool));
+
+// u64
+limb_function!(wrapping_uscalar_i64, wrapping_ulimb_i64, wrapping_uwide_i32, &[ULimb; N], u64, ret => [ULimb; N]);
+limb_function!(wrapping_iscalar_i64, wrapping_ilimb_i64, wrapping_iwide_i32, &[ULimb; N], i64, ret => [ULimb; N]);
+limb_function!(overflowing_uscalar_i64, overflowing_ulimb_i64, overflowing_uwide_i32, &[ULimb; N], u64, ret => ([ULimb; N], bool));
+limb_function!(overflowing_iscalar_i64, overflowing_ilimb_i64, overflowing_iwide_i32, &[ULimb; N], i64, ret => ([ULimb; N], bool));
 
 #[cfg(test)]
 mod tests {

--- a/src/math/add.rs
+++ b/src/math/add.rs
@@ -1,15 +1,21 @@
 //! Const implementations of addition.
 
 use super::bigint::*;
-use crate::{ILimb, ULimb};
+use crate::{ILimb, IWide, ULimb, UWide};
 
 macro_rules! unsigned_define {
     (
-        $u:ty,wrapping_full =>
+        type =>
+        $u:ty,wide =>
+        $w:ty,wrapping_full =>
         $wrapping_full:ident,overflowing_full =>
         $overflowing_full:ident,wrapping_limb =>
         $wrapping_limb:ident,overflowing_limb =>
-        $overflowing_limb:ident,carrying =>
+        $overflowing_limb:ident,wrapping_wide =>
+        $wrapping_wide:ident,overflowing_wide =>
+        $overflowing_wide:ident,wrapping_mn =>
+        $wrapping_mn:ident,overflowing_mn =>
+        $overflowing_mn:ident,carrying =>
         $carrying:ident $(,)?
     ) => {
         /// Const implementation of `wrapping_add` for internal algorithm use.
@@ -94,14 +100,11 @@ macro_rules! unsigned_define {
             let mut result = [0; N];
             let mut c: bool = false;
             let mut vi: $u;
-            while index < N - 1 {
+            while index < N {
                 (vi, c) = $carrying(ne_index!(x[index]), ne_index!(y[index]), c);
                 ne_index!(result[index] = vi);
                 index += 1;
             }
-
-            let (vn, c) = $carrying(ne_index!(x[index]), ne_index!(y[index]), c);
-            ne_index!(result[index] = vn);
 
             (result, c)
         }
@@ -190,53 +193,149 @@ macro_rules! unsigned_define {
             let (mut v, mut c) = ne_index!(x[index]).overflowing_add(y);
             ne_index!(result[index] = v);
             index += 1;
-            while index < N - 1 {
+            while index < N {
                 (v, c) = ne_index!(x[index]).overflowing_add(c as $u);
                 ne_index!(result[index] = v);
                 index += 1;
             }
 
-            (v, c) = ne_index!(x[index]).overflowing_add(c as $u);
-            ne_index!(result[index] = v);
+            (result, c)
+        }
+
+        /// Const implementation of `wrapping_add` for internal algorithm use.
+        // NOTE: This differs significantly from `wrapping_full`.
+        #[inline]
+        pub const fn $wrapping_mn<const M: usize, const N: usize>(
+            x: &[$u; M],
+            y: &[$u; N],
+        ) -> [$u; M] {
+            assert!(N >= 2 && M > N);
+
+            let mut index = 0;
+            let mut result = [0; M];
+            let mut c: bool = false;
+            let mut vi: $u;
+
+            while index < N {
+                (vi, c) = $carrying(ne_index!(x[index]), ne_index!(y[index]), c);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+
+            while index < M - 1 {
+                (vi, c) = ne_index!(x[index]).overflowing_add(c as $u);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+            ne_index!(result[index] = ne_index!(x[index]).wrapping_add(c as $u));
+
+            result
+        }
+
+        /// Const implementation of `overflowing_add` for internal algorithm use.
+        // NOTE: This differs significantly from `overflowing_full`.
+        #[inline]
+        pub const fn $overflowing_mn<const M: usize, const N: usize>(
+            x: &[$u; M],
+            y: &[$u; N],
+        ) -> ([$u; M], bool) {
+            assert!(N >= 2 && M > N);
+
+            let mut index = 0;
+            let mut result = [0; M];
+            let mut c: bool = false;
+            let mut vi: $u;
+
+            while index < N {
+                (vi, c) = $carrying(ne_index!(x[index]), ne_index!(y[index]), c);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+
+            while index < M {
+                (vi, c) = ne_index!(x[index]).overflowing_add(c as $u);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
 
             (result, c)
+        }
+
+        /// Const implementation of `wrapping_add` a small number to the wider type.
+        #[inline]
+        pub const fn $wrapping_wide<const N: usize>(x: &[$u; N], y: $w) -> [$u; N] {
+            let mut rhs = [0; 2];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $wrapping_mn(x, &rhs)
+        }
+
+        /// Const implementation of `overflowing_add` a small number to the wider type.
+        #[inline]
+        pub const fn $overflowing_wide<const N: usize>(x: &[$u; N], y: $w) -> ([$u; N], bool) {
+            let mut rhs = [0; 2];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $overflowing_mn(x, &rhs)
         }
     };
 }
 
 unsigned_define!(
-    u32,
+    type => u32,
+    wide => u64,
     wrapping_full => wrapping_u32,
     overflowing_full => overflowing_u32,
     wrapping_limb => wrapping_limb_u32,
     overflowing_limb => overflowing_limb_u32,
+    wrapping_wide => wrapping_wide_u32,
+    overflowing_wide => overflowing_wide_u32,
+    wrapping_mn => wrapping_mn_u32,
+    overflowing_mn => overflowing_mn_u32,
     carrying => carrying_add_u32,
 );
 unsigned_define!(
-    u64,
+    type => u64,
+    wide => u128,
     wrapping_full => wrapping_u64,
     overflowing_full => overflowing_u64,
     wrapping_limb => wrapping_limb_u64,
     overflowing_limb => overflowing_limb_u64,
+    wrapping_wide => wrapping_wide_u64,
+    overflowing_wide => overflowing_wide_u64,
+    wrapping_mn => wrapping_mn_u64,
+    overflowing_mn => overflowing_mn_u64,
     carrying => carrying_add_u64,
 );
 
 limb_function!(wrapping_unsigned, wrapping_u64, wrapping_u32, &[ULimb; N], ret => [ULimb; N]);
 limb_function!(overflowing_unsigned, overflowing_u64, overflowing_u32, &[ULimb; N], &[ULimb; N], ret => ([ULimb; N], bool));
 
+// limb
 limb_function!(wrapping_limb, wrapping_limb_u64, wrapping_limb_u32, &[ULimb; N], ULimb, ret => [ULimb; N]);
 limb_function!(overflowing_limb, overflowing_limb_u64, overflowing_limb_u32, &[ULimb; N], ULimb, ret => ([ULimb; N], bool));
 
+// wide
+limb_function!(wrapping_wide, wrapping_wide_u64, wrapping_wide_u32, &[ULimb; N], UWide, ret => [ULimb; N]);
+limb_function!(overflowing_wide, overflowing_wide_u64, overflowing_wide_u32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
+
 macro_rules! signed_define {
     (
-        $u:ty,
-        $s:ty,wrapping_full =>
+        unsigned =>
+        $u:ty,signed =>
+        $s:ty,unsigned_wide =>
+        $uw:ty,signed_wide =>
+        $sw:ty,wrapping_full =>
         $wrapping_full:ident,overflowing_full =>
         $overflowing_full:ident,wrapping_ulimb =>
         $wrapping_ulimb:ident,overflowing_ulimb =>
         $overflowing_ulimb:ident,wrapping_ilimb =>
         $wrapping_ilimb:ident,overflowing_ilimb =>
-        $overflowing_ilimb:ident,carrying =>
+        $overflowing_ilimb:ident,wrapping_uwide =>
+        $wrapping_uwide:ident,overflowing_uwide =>
+        $overflowing_uwide:ident,wrapping_iwide =>
+        $wrapping_iwide:ident,overflowing_iwide =>
+        $overflowing_iwide:ident,carrying =>
         $carrying:ident $(,)?
     ) => {
         /// Const implementation of `wrapping_add` for internal algorithm use.
@@ -542,39 +641,94 @@ macro_rules! signed_define {
             ne_index!(rhs[0] = y as $u);
             $overflowing_full(x, &rhs)
         }
+
+        /// Const implementation to add a small, unsigned number to the wider type.
+        pub const fn $wrapping_uwide<const N: usize>(x: &[$u; N], y: $uw) -> [$u; N] {
+            let mut rhs = [0; N];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $wrapping_full(x, &rhs)
+        }
+
+        /// Const implementation to add a small, unsigned number to the wider type.
+        pub const fn $overflowing_uwide<const N: usize>(x: &[$u; N], y: $uw) -> ([$u; N], bool) {
+            let mut rhs = [0; N];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $overflowing_full(x, &rhs)
+        }
+
+        /// Const implementation to add a small, signed number to the wider type.
+        pub const fn $wrapping_iwide<const N: usize>(x: &[$u; N], y: $sw) -> [$u; N] {
+            let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
+            let mut rhs = [sign_bit; N];
+            let y = y as $uw;
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $wrapping_full(x, &rhs)
+        }
+
+        /// Const implementation to add a small, signed number to the wider type.
+        pub const fn $overflowing_iwide<const N: usize>(x: &[$u; N], y: $sw) -> ([$u; N], bool) {
+            let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
+            let mut rhs = [sign_bit; N];
+            let y = y as $uw;
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $overflowing_full(x, &rhs)
+        }
     };
 }
 
 signed_define!(
-    u32,
-    i32,
+    unsigned => u32,
+    signed => i32,
+    unsigned_wide => u64,
+    signed_wide => i64,
     wrapping_full => wrapping_i32,
     overflowing_full => overflowing_i32,
     wrapping_ulimb => wrapping_ulimb_i32,
     overflowing_ulimb => overflowing_ulimb_i32,
     wrapping_ilimb => wrapping_ilimb_i32,
     overflowing_ilimb => overflowing_ilimb_i32,
+    wrapping_uwide => wrapping_uwide_i32,
+    overflowing_uwide => overflowing_uwide_i32,
+    wrapping_iwide => wrapping_iwide_i32,
+    overflowing_iwide => overflowing_iwide_i32,
     carrying => carrying_add_u32,
 );
 signed_define!(
-    u64,
-    i64,
+    unsigned => u64,
+    signed => i64,
+    unsigned_wide => u128,
+    signed_wide => i128,
     wrapping_full => wrapping_i64,
     overflowing_full => overflowing_i64,
     wrapping_ulimb => wrapping_ulimb_i64,
     overflowing_ulimb => overflowing_ulimb_i64,
     wrapping_ilimb => wrapping_ilimb_i64,
     overflowing_ilimb => overflowing_ilimb_i64,
+    wrapping_uwide => wrapping_uwide_i64,
+    overflowing_uwide => overflowing_uwide_i64,
+    wrapping_iwide => wrapping_iwide_i64,
+    overflowing_iwide => overflowing_iwide_i64,
     carrying => carrying_add_u64,
 );
 
 limb_function!(wrapping_signed, wrapping_i64, wrapping_i32, &[ULimb; N], ret => [ULimb; N]);
 limb_function!(overflowing_signed, overflowing_i64, overflowing_i32, &[ULimb; N], &[ULimb; N], ret => ([ULimb; N], bool));
 
+// limb
 limb_function!(wrapping_ulimb, wrapping_ulimb_i64, wrapping_ulimb_i32, &[ULimb; N], ULimb, ret => [ULimb; N]);
 limb_function!(wrapping_ilimb, wrapping_ilimb_i64, wrapping_ilimb_i32, &[ULimb; N], ILimb, ret => [ULimb; N]);
 limb_function!(overflowing_ulimb, overflowing_ulimb_i64, overflowing_ulimb_i32, &[ULimb; N], ULimb, ret => ([ULimb; N], bool));
 limb_function!(overflowing_ilimb, overflowing_ilimb_i64, overflowing_ilimb_i32, &[ULimb; N], ILimb, ret => ([ULimb; N], bool));
+
+// wide
+limb_function!(wrapping_uwide, wrapping_uwide_i64, wrapping_uwide_i32, &[ULimb; N], UWide, ret => [ULimb; N]);
+limb_function!(wrapping_iwide, wrapping_iwide_i64, wrapping_iwide_i32, &[ULimb; N], IWide, ret => [ULimb; N]);
+limb_function!(overflowing_uwide, overflowing_uwide_i64, overflowing_uwide_i32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
+limb_function!(overflowing_iwide, overflowing_iwide_i64, overflowing_iwide_i32, &[ULimb; N], IWide, ret => ([ULimb; N], bool));
 
 #[cfg(test)]
 mod tests {

--- a/src/math/div.rs
+++ b/src/math/div.rs
@@ -95,6 +95,36 @@ pub fn wide<const M: usize>(numerator: &[ULimb; M], divisor: UWide) -> ([ULimb; 
     (quo, rem)
 }
 
+/// Implementation like above, except considering we might have 4 values.
+#[inline]
+#[cfg(feature = "stdint")]
+#[allow(clippy::assertions_on_constants)]
+pub fn from_u128<const M: usize>(numerator: &[ULimb; M], divisor: u128) -> ([ULimb; M], u128) {
+    assert!(ULimb::BITS == 32);
+
+    // NOTE: It's way better to keep this optimization outside the comparison.
+    if M >= 2 && is_zero(numerator, 2) {
+        // Can do as a scalar operation, simple.
+        if numerator[0] == 0 && numerator[1] == 0 {
+            return (scalar1(0), 0);
+        } else {
+            let numerator = u128_scalar(numerator);
+            let (quo, rem) = (numerator / divisor, numerator % divisor);
+            return (scalar_u128(quo), rem);
+        }
+    }
+
+    let y = scalar_u128::<M>(divisor);
+    let (quo, rem) = match cmp(numerator, &y) {
+        Ordering::Less => ([0; M], truncate(*numerator)),
+        Ordering::Equal => return (scalar1(1), 0),
+        Ordering::Greater => full_gt(numerator, &y),
+    };
+    let rem = u128_scalar(&rem);
+
+    (quo, rem)
+}
+
 /// Division of numerator by a u64 divisor
 #[inline]
 pub fn limb<const M: usize>(numerator: &[ULimb; M], divisor: ULimb) -> ([ULimb; M], ULimb) {
@@ -212,6 +242,38 @@ pub const fn scalar2<const N: usize>(value: UWide) -> [ULimb; N] {
     r[0] = value as ULimb;
     r[1] = (value >> ULimb::BITS) as ULimb;
     r
+}
+
+/// Construct an array from a u128 value. Only used for 32-bit ISAs.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[allow(clippy::assertions_on_constants)]
+pub const fn scalar_u128<const N: usize>(value: u128) -> [ULimb; N] {
+    assert!(N >= 4);
+    assert!(ULimb::BITS == 32);
+
+    let mut r = [0; N];
+    r[0] = value as ULimb;
+    r[1] = (value >> 32) as ULimb;
+    r[2] = (value >> 64) as ULimb;
+    r[3] = (value >> 96) as ULimb;
+    r
+}
+
+/// Construct an array from a u128 value. Only used for 32-bit ISAs.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[allow(clippy::assertions_on_constants)]
+pub const fn u128_scalar<const N: usize>(value: &[ULimb; N]) -> u128 {
+    assert!(N >= 4);
+    assert!(ULimb::BITS == 32);
+
+    let x0 = value[0] as u128;
+    let x1 = (value[1] as u128) << 32;
+    let x2 = (value[2] as u128) << 64;
+    let x3 = (value[3] as u128) << 96;
+
+    x0 | x1 | x2 | x3
 }
 
 /// Division of numerator by a u64 divisor

--- a/src/math/div.rs
+++ b/src/math/div.rs
@@ -41,6 +41,7 @@ use crate::types::{ULimb, UWide};
 ///
 /// Panics if divisor is zero.
 #[inline]
+#[must_use]
 pub fn full<const M: usize, const N: usize>(
     numerator: &[ULimb; M],
     divisor: &[ULimb; N],
@@ -69,6 +70,7 @@ pub fn full<const M: usize, const N: usize>(
 /// due to the creation of the temporary divisor it
 /// can be significantly slower.
 #[inline]
+#[must_use]
 pub fn wide<const M: usize>(numerator: &[ULimb; M], divisor: UWide) -> ([ULimb; M], UWide) {
     // NOTE: It's way better to keep this optimization outside the comparison.
     if M >= 2 && is_zero(numerator, 2) {
@@ -97,6 +99,7 @@ pub fn wide<const M: usize>(numerator: &[ULimb; M], divisor: UWide) -> ([ULimb; 
 
 /// Implementation like above, except considering we might have 4 values.
 #[inline]
+#[must_use]
 #[cfg(feature = "stdint")]
 #[allow(clippy::assertions_on_constants)]
 pub fn from_u128<const M: usize>(numerator: &[ULimb; M], divisor: u128) -> ([ULimb; M], u128) {
@@ -127,6 +130,7 @@ pub fn from_u128<const M: usize>(numerator: &[ULimb; M], divisor: u128) -> ([ULi
 
 /// Division of numerator by a u64 divisor
 #[inline]
+#[must_use]
 pub fn limb<const M: usize>(numerator: &[ULimb; M], divisor: ULimb) -> ([ULimb; M], ULimb) {
     // quick path optinmization for small values
     if M >= 2 && is_zero(numerator, 2) {

--- a/src/math/mul.rs
+++ b/src/math/mul.rs
@@ -75,6 +75,7 @@ macro_rules! unsigned_define {
         /// Returns the low and high bits, in that order.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_full<const M: usize, const N: usize>(
             x: &[$t; M],
@@ -119,12 +120,14 @@ macro_rules! unsigned_define {
         }
 
         /// Const implementation of `wrapping_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_limb<const N: usize>(x: &[$t; N], y: $t) -> [$t; N] {
             $wrapping_full(&x, &[y])
         }
 
         /// Const implementation of `wrapping_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_wide<const N: usize>(x: &[$t; N], y: $w) -> [$t; N] {
             let mut rhs = [0; 2];
@@ -146,6 +149,7 @@ macro_rules! unsigned_define {
         /// Returns the low and high bits, in that order.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_full<const M: usize, const N: usize>(
             x: &[$t; M],
@@ -203,12 +207,14 @@ macro_rules! unsigned_define {
         }
 
         /// Const implementation of `overflowing_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_limb<const N: usize>(x: &[$t; N], y: $t) -> ([$t; N], bool) {
             $overflowing_full(&x, &[y])
         }
 
         /// Const implementation of `overflowing_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_wide<const N: usize>(x: &[$t; N], y: $w) -> ([$t; N], bool) {
             let mut rhs = [0; 2];
@@ -299,7 +305,8 @@ macro_rules! signed_define {
         /// All the other optimization caveats are as described above.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $wrapping_full<const M: usize, const N: usize>(
             x: &[$u; M],
             y: &[$u; N],
@@ -335,12 +342,14 @@ macro_rules! signed_define {
         /// All the other optimization caveats are as described above.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_ulimb<const N: usize>(x: &[$u; N], y: $u) -> [$u; N] {
             $wrapping_unsigned(&x, &[y])
         }
 
         /// Const implementation of `wrapping_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_uwide<const N: usize>(x: &[$u; N], y: $uw) -> [$u; N] {
             let mut rhs = [0; 2];
@@ -375,6 +384,7 @@ macro_rules! signed_define {
         /// All the other optimization caveats are as described above.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_ilimb<const N: usize>(x: &[$u; N], y: $s) -> [$u; N] {
             // NOTE: This does not work like above, but there is a trick.
@@ -386,6 +396,7 @@ macro_rules! signed_define {
         }
 
         /// Const implementation of `wrapping_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $wrapping_iwide<const N: usize>(x: &[$u; N], y: $sw) -> [$u; N] {
             // NOTE: This does not work like above, but there is a trick.
@@ -417,7 +428,8 @@ macro_rules! signed_define {
         /// The analysis here is practically identical to that of `wrapping_full`.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $overflowing_full<const M: usize, const N: usize>(
             x: &[$u; M],
             y: &[$u; N],
@@ -481,6 +493,7 @@ macro_rules! signed_define {
         /// The analysis here is practically identical to that of `wrapping_ulimb`.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_ulimb<const N: usize>(x: &[$u; N], y: $u) -> ([$u; N], bool) {
             let mut rhs = [0; N];
@@ -489,6 +502,7 @@ macro_rules! signed_define {
         }
 
         /// Const implementation of `wrapping_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_uwide<const N: usize>(x: &[$u; N], y: $uw) -> ([$u; N], bool) {
             let mut rhs = [0; N];
@@ -520,6 +534,7 @@ macro_rules! signed_define {
         /// The analysis here is practically identical to that of `wrapping_ilimb`.
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_ilimb<const N: usize>(x: &[$u; N], y: $s) -> ([$u; N], bool) {
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
@@ -529,6 +544,7 @@ macro_rules! signed_define {
         }
 
         /// Const implementation of `overflowing_mul` for internal algorithm use.
+        #[must_use]
         #[inline(always)]
         pub const fn $overflowing_iwide<const N: usize>(x: &[$u; N], y: $sw) -> ([$u; N], bool) {
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);

--- a/src/math/mul.rs
+++ b/src/math/mul.rs
@@ -242,8 +242,8 @@ unsigned_define!(
     mac => mac_u64,
 );
 
-limb_function!(wrapping_unsigned, wrapping_u64, wrapping_u32, &[ULimb; N], ret => [ULimb; N]);
-limb_function!(overflowing_unsigned, overflowing_u64, overflowing_u32, &[ULimb; N], &[ULimb; N], ret => ([ULimb; N], bool));
+limb_function!(mn wrapping_unsigned, wrapping_u64, wrapping_u32, &[ULimb; M], &[ULimb; N], ret => [ULimb; M]);
+limb_function!(mn overflowing_unsigned, overflowing_u64, overflowing_u32, &[ULimb; M], &[ULimb; N], ret => ([ULimb; M], bool));
 
 // limb
 limb_function!(wrapping_limb, wrapping_limb_u64, wrapping_limb_u32, &[ULimb; N], ULimb, ret => [ULimb; N]);
@@ -252,6 +252,10 @@ limb_function!(overflowing_limb, overflowing_limb_u64, overflowing_limb_u32, &[U
 // wide
 limb_function!(wrapping_wide, wrapping_wide_u64, wrapping_wide_u32, &[ULimb; N], UWide, ret => [ULimb; N]);
 limb_function!(overflowing_wide, overflowing_wide_u64, overflowing_wide_u32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
+
+// u64
+limb_function!(wrapping_scalar_u64, wrapping_limb_u64, wrapping_wide_u32, &[ULimb; N], u64, ret => [ULimb; N]);
+limb_function!(overflowing_scalar_u64, overflowing_limb_u64, overflowing_wide_u32, &[ULimb; N], u64, ret => ([ULimb; N], bool));
 
 macro_rules! signed_define {
     (
@@ -588,6 +592,12 @@ limb_function!(wrapping_uwide, wrapping_uwide_i64, wrapping_uwide_i32, &[ULimb; 
 limb_function!(wrapping_iwide, wrapping_iwide_i64, wrapping_iwide_i32, &[ULimb; N], IWide, ret => [ULimb; N]);
 limb_function!(overflowing_uwide, overflowing_uwide_i64, overflowing_uwide_i32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
 limb_function!(overflowing_iwide, overflowing_iwide_i64, overflowing_iwide_i32, &[ULimb; N], IWide, ret => ([ULimb; N], bool));
+
+// u64
+limb_function!(wrapping_uscalar_i64, wrapping_ulimb_i64, wrapping_uwide_i32, &[ULimb; N], u64, ret => [ULimb; N]);
+limb_function!(wrapping_iscalar_i64, wrapping_ilimb_i64, wrapping_iwide_i32, &[ULimb; N], i64, ret => [ULimb; N]);
+limb_function!(overflowing_uscalar_i64, overflowing_ulimb_i64, overflowing_uwide_i32, &[ULimb; N], u64, ret => ([ULimb; N], bool));
+limb_function!(overflowing_iscalar_i64, overflowing_ilimb_i64, overflowing_iwide_i32, &[ULimb; N], i64, ret => ([ULimb; N], bool));
 
 macro_rules! widening_define {
     (type => $t:ty,name => $name:ident,mac => $mac:ident $(,)?) => {

--- a/src/math/mul.rs
+++ b/src/math/mul.rs
@@ -127,9 +127,10 @@ macro_rules! unsigned_define {
         /// Const implementation of `wrapping_mul` for internal algorithm use.
         #[inline(always)]
         pub const fn $wrapping_wide<const N: usize>(x: &[$t; N], y: $w) -> [$t; N] {
-            let lo = y as $t;
-            let hi = (y >> <$t>::BITS) as $t;
-            $wrapping_full(&x, &[lo, hi])
+            let mut rhs = [0; 2];
+            ne_index!(rhs[0] = y as $t);
+            ne_index!(rhs[1] = (y >> <$t>::BITS) as $t);
+            $wrapping_full(&x, &rhs)
         }
 
         /// Const implementation of `overflowing_mul` for internal algorithm use.
@@ -210,9 +211,10 @@ macro_rules! unsigned_define {
         /// Const implementation of `overflowing_mul` for internal algorithm use.
         #[inline(always)]
         pub const fn $overflowing_wide<const N: usize>(x: &[$t; N], y: $w) -> ([$t; N], bool) {
-            let lo = y as $t;
-            let hi = (y >> <$t>::BITS) as $t;
-            $overflowing_full(&x, &[lo, hi])
+            let mut rhs = [0; 2];
+            ne_index!(rhs[0] = y as $t);
+            ne_index!(rhs[1] = (y >> <$t>::BITS) as $t);
+            $overflowing_full(&x, &rhs)
         }
     };
 }
@@ -340,7 +342,6 @@ macro_rules! signed_define {
             let mut rhs = [0; 2];
             ne_index!(rhs[0] = y as $u);
             ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
-            let lo = y as $u;
             $wrapping_unsigned(&x, &rhs)
         }
 

--- a/src/math/rotate.rs
+++ b/src/math/rotate.rs
@@ -55,8 +55,8 @@ macro_rules! define {
         ///
         /// [`shld`]: https://www.felixcloutier.com/x86/shld
         /// [`shrd`]: https://www.felixcloutier.com/x86/shrd
-        #[inline]
         #[must_use]
+        #[inline(always)]
         pub const fn $left<const N: usize>(x: [$u; N], n: u32) -> [$u; N] {
             assert!(N >= 2, "must have at least 2 limbs");
             // 0bXYFFFF -> 0bFFFFXY
@@ -130,8 +130,8 @@ macro_rules! define {
         ///
         /// [`shld`]: https://www.felixcloutier.com/x86/shld
         /// [`shrd`]: https://www.felixcloutier.com/x86/shrd
-        #[inline]
         #[must_use]
+        #[inline(always)]
         pub const fn $right<const N: usize>(x: [$u; N], n: u32) -> [$u; N] {
             assert!(N >= 2, "must have at least 2 limbs");
             // See rotate_left for the description

--- a/src/math/rotate.rs
+++ b/src/math/rotate.rs
@@ -134,55 +134,10 @@ macro_rules! define {
         #[inline(always)]
         pub const fn $right<const N: usize>(x: [$u; N], n: u32) -> [$u; N] {
             assert!(N >= 2, "must have at least 2 limbs");
-            // See rotate_left for the description
             // 0bFFFFXY -> 0bXYFFFF
             const BITS: u32 = <$u>::BITS;
-            let n = n % (N as u32 * BITS);
-            let limb_n = (n >> BITS.trailing_zeros()) as usize;
-            let bits_n = n & (BITS - 1);
-            let inv_n = BITS - bits_n;
-
-            let mut result = [0; N];
-            if N ==  2 {
-                // Simple case, only have to worry about swapping bits, at most swap 1 limb.
-                let (x0, x1) = if limb_n != 0 {
-                    (ne_index!(x[1]), ne_index!(x[0]))
-                } else {
-                    (ne_index!(x[0]), ne_index!(x[1]))
-                };
-                let (r0, r1) = if bits_n == 0 {
-                    (x0, x1)
-                } else {
-                    let hi = (x1 >> bits_n) | (x0 << BITS - bits_n);
-                    let lo = (x0 >> bits_n) | (x1 << BITS - bits_n);
-                    (lo, hi)
-                };
-                ne_index!(result[0] = r0);
-                ne_index!(result[1] = r1);
-            } else if bits_n != 0 {
-                let mut index = 0;
-                let mut carry = 0;
-                while index < N {
-                    let rot_n = (index + limb_n) % N;
-                    let xi = ne_index!(x[rot_n]);
-                    let ri = (xi >> bits_n) | carry;
-                    carry = xi << inv_n;
-                    ne_index!(result[index] = ri);
-                    index += 1;
-                }
-                ne_index!(result[0] = ne_index!(result[0]) | carry);
-            } else {
-                // no bit shift, just limb shifts
-                let mut index = 0;
-                while index < N {
-                    let rot_n = (index + limb_n) % N;
-                    let xi = ne_index!(x[rot_n]);
-                    ne_index!(result[index] = xi);
-                    index += 1;
-                }
-            }
-
-            result
+            let n = n % (BITS * N as u32);
+            $left(x, (BITS * N as u32) - n)
         }
     )*);
 }

--- a/src/math/shift.rs
+++ b/src/math/shift.rs
@@ -82,8 +82,8 @@ macro_rules! define {
         ///     (lo, hi | carry)
         /// }
         /// ```
-        #[inline]
         #[must_use]
+        #[inline(always)]
         pub const fn $left<const N: usize, const SIGNED: bool>(x: [$u; N], shift: u32) -> [$u; N] {
             // NOTE: Signed and unsigned are identical
             assert!(N >= 2, "must have at least 2 limbs");
@@ -207,8 +207,8 @@ macro_rules! define {
         ///     (lo, hi | carry)
         /// }
         /// ```
-        #[inline]
         #[must_use]
+        #[inline(always)]
         pub const fn $right<const N: usize, const SIGNED: bool>(x: [$u; N], shift: u32) -> [$u; N] {
             assert!(N >= 2, "must have at least 2 limbs");
             const BITS: u32 = <$u>::BITS;

--- a/src/math/sub.rs
+++ b/src/math/sub.rs
@@ -98,14 +98,11 @@ macro_rules! unsigned_define {
             let mut result = [0; N];
             let mut c: bool = false;
             let mut vi: $u;
-            while index < N - 1 {
+            while index < N {
                 (vi, c) = $borrowing(ne_index!(x[index]), ne_index!(y[index]), c);
                 ne_index!(result[index] = vi);
                 index += 1;
             }
-
-            let (vn, c) = $borrowing(ne_index!(x[index]), ne_index!(y[index]), c);
-            ne_index!(result[index] = vn);
 
             (result, c)
         }
@@ -195,14 +192,11 @@ macro_rules! unsigned_define {
             let (mut v, mut c) = ne_index!(x[index]).overflowing_sub(y);
             ne_index!(result[index] = v);
             index += 1;
-            while index < N - 1 {
+            while index < N {
                 (v, c) = ne_index!(x[index]).overflowing_sub(c as $u);
                 ne_index!(result[index] = v);
                 index += 1;
             }
-
-            (v, c) = ne_index!(x[index]).overflowing_sub(c as $u);
-            ne_index!(result[index] = v);
 
             (result, c)
         }

--- a/src/math/sub.rs
+++ b/src/math/sub.rs
@@ -324,6 +324,10 @@ limb_function!(overflowing_limb, overflowing_limb_u64, overflowing_limb_u32, &[U
 limb_function!(wrapping_wide, wrapping_wide_u64, wrapping_wide_u32, &[ULimb; N], UWide, ret => [ULimb; N]);
 limb_function!(overflowing_wide, overflowing_wide_u64, overflowing_wide_u32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
 
+// u64
+limb_function!(wrapping_scalar_u64, wrapping_limb_u64, wrapping_wide_u32, &[ULimb; N], u64, ret => [ULimb; N]);
+limb_function!(overflowing_scalar_u64, overflowing_limb_u64, overflowing_wide_u32, &[ULimb; N], u64, ret => ([ULimb; N], bool));
+
 macro_rules! signed_define {
     (
         unsigned =>
@@ -734,6 +738,15 @@ limb_function!(wrapping_uwide, wrapping_uwide_i64, wrapping_uwide_i32, &[ULimb; 
 limb_function!(wrapping_iwide, wrapping_iwide_i64, wrapping_iwide_i32, &[ULimb; N], IWide, ret => [ULimb; N]);
 limb_function!(overflowing_uwide, overflowing_uwide_i64, overflowing_uwide_i32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
 limb_function!(overflowing_iwide, overflowing_iwide_i64, overflowing_iwide_i32, &[ULimb; N], IWide, ret => ([ULimb; N], bool));
+
+// u64
+limb_function!(wrapping_uscalar_i64, wrapping_ulimb_i64, wrapping_uwide_i32, &[ULimb; N], u64, ret => [ULimb; N]);
+limb_function!(wrapping_iscalar_i64, wrapping_ilimb_i64, wrapping_iwide_i32, &[ULimb; N], i64, ret => [ULimb; N]);
+limb_function!(overflowing_uscalar_i64, overflowing_ulimb_i64, overflowing_uwide_i32, &[ULimb; N], u64, ret => ([ULimb; N], bool));
+limb_function!(overflowing_iscalar_i64, overflowing_ilimb_i64, overflowing_iwide_i32, &[ULimb; N], i64, ret => ([ULimb; N], bool));
+// u128
+limb_function!(mn wrapping_mn, wrapping_mn_u64, wrapping_mn_u32, &[ULimb; M], &[ULimb; N], ret => [ULimb; M]);
+limb_function!(mn overflowing_mn, overflowing_mn_u64, overflowing_mn_u32, &[ULimb; M], &[ULimb; N], ret => ([ULimb; M], bool));
 
 #[cfg(test)]
 mod tests {

--- a/src/math/sub.rs
+++ b/src/math/sub.rs
@@ -46,6 +46,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_full<const N: usize>(x: &[$u; N], y: &[$u; N]) -> [$u; N] {
             assert!(N >= 2);
 
@@ -94,6 +95,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_full<const N: usize>(
             x: &[$u; N],
             y: &[$u; N],
@@ -141,6 +143,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $wrapping_limb<const N: usize>(x: &[$u; N], y: $u) -> [$u; N] {
             assert!(N >= 2);
 
@@ -190,6 +193,7 @@ macro_rules! unsigned_define {
         ///     ret
         /// ```
         #[inline]
+        #[must_use]
         pub const fn $overflowing_limb<const N: usize>(x: &[$u; N], y: $u) -> ([$u; N], bool) {
             assert!(N >= 2);
 
@@ -210,6 +214,7 @@ macro_rules! unsigned_define {
         /// Const implementation of `wrapping_sub` for internal algorithm use.
         // NOTE: This differs significantly from `wrapping_full`.
         #[inline]
+        #[must_use]
         pub const fn $wrapping_mn<const M: usize, const N: usize>(
             x: &[$u; M],
             y: &[$u; N],
@@ -240,6 +245,7 @@ macro_rules! unsigned_define {
         /// Const implementation of `overflowing_sub` for internal algorithm use.
         // NOTE: This differs significantly from `overflowing_full`.
         #[inline]
+        #[must_use]
         pub const fn $overflowing_mn<const M: usize, const N: usize>(
             x: &[$u; M],
             y: &[$u; N],
@@ -268,6 +274,7 @@ macro_rules! unsigned_define {
 
         /// Const implementation of `wrapping_sub` a small number to the wider type.
         #[inline]
+        #[must_use]
         pub const fn $wrapping_wide<const N: usize>(x: &[$u; N], y: $w) -> [$u; N] {
             let mut rhs = [0; 2];
             ne_index!(rhs[0] = y as $u);
@@ -277,6 +284,7 @@ macro_rules! unsigned_define {
 
         /// Const implementation of `overflowing_sub` a small number to the wider type.
         #[inline]
+        #[must_use]
         pub const fn $overflowing_wide<const N: usize>(x: &[$u; N], y: $w) -> ([$u; N], bool) {
             let mut rhs = [0; 2];
             ne_index!(rhs[0] = y as $u);
@@ -374,7 +382,8 @@ macro_rules! signed_define {
         ///     mov     qword ptr [rax + 24], rsi
         ///     ret
         /// ```
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $wrapping_full<const N: usize>(x: &[$u; N], y: &[$u; N]) -> [$u; N] {
             assert!(<$u>::BITS == <$s>::BITS);
             assert!(N >= 2);
@@ -428,7 +437,8 @@ macro_rules! signed_define {
         ///     mov     byte ptr [rdi + 32], dl
         ///     ret
         /// ```
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $overflowing_full<const N: usize>(
             x: &[$u; N],
             y: &[$u; N],
@@ -495,7 +505,8 @@ macro_rules! signed_define {
         ///     mov     qword ptr [rdi + 24], rsi
         ///     ret
         /// ```
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $wrapping_ulimb<const N: usize>(x: &[$u; N], y: $u) -> [$u; N] {
             assert!(N >= 2);
             assert!(<$u>::BITS == <$s>::BITS);
@@ -546,7 +557,8 @@ macro_rules! signed_define {
         ///     seto    byte ptr [rdi + 32]
         ///     ret
         /// ```
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $overflowing_ulimb<const N: usize>(x: &[$u; N], y: $u) -> ([$u; N], bool) {
             assert!(N >= 2);
             assert!(<$u>::BITS == <$s>::BITS);
@@ -599,7 +611,8 @@ macro_rules! signed_define {
         ///     mov     qword ptr [rdi + 24], rcx
         ///     ret
         /// ```
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $wrapping_ilimb<const N: usize>(x: &[$u; N], y: $s) -> [$u; N] {
             // NOTE: We just want to set it as the low bits of `y` and the single high bit.
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
@@ -642,7 +655,8 @@ macro_rules! signed_define {
         ///     mov     byte ptr [rax + 32], cl
         ///     ret
         /// ```
-        #[inline]
+        #[must_use]
+        #[inline(always)]
         pub const fn $overflowing_ilimb<const N: usize>(x: &[$u; N], y: $s) -> ([$u; N], bool) {
             // NOTE: We just want to set it as the low bits of `y` and the single high bit.
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
@@ -652,6 +666,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to subtract a small, unsigned number to the wider type.
+        #[must_use]
+        #[inline(always)]
         pub const fn $wrapping_uwide<const N: usize>(x: &[$u; N], y: $uw) -> [$u; N] {
             let mut rhs = [0; N];
             ne_index!(rhs[0] = y as $u);
@@ -660,6 +676,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to subtract a small, unsigned number to the wider type.
+        #[must_use]
+        #[inline(always)]
         pub const fn $overflowing_uwide<const N: usize>(x: &[$u; N], y: $uw) -> ([$u; N], bool) {
             let mut rhs = [0; N];
             ne_index!(rhs[0] = y as $u);
@@ -668,6 +686,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to subtract a small, signed number to the wider type.
+        #[must_use]
+        #[inline(always)]
         pub const fn $wrapping_iwide<const N: usize>(x: &[$u; N], y: $sw) -> [$u; N] {
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
             let mut rhs = [sign_bit; N];
@@ -678,6 +698,8 @@ macro_rules! signed_define {
         }
 
         /// Const implementation to subtract a small, signed number to the wider type.
+        #[must_use]
+        #[inline(always)]
         pub const fn $overflowing_iwide<const N: usize>(x: &[$u; N], y: $sw) -> ([$u; N], bool) {
             let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
             let mut rhs = [sign_bit; N];

--- a/src/math/sub.rs
+++ b/src/math/sub.rs
@@ -1,15 +1,21 @@
 //! Const implementations of subtraction.
 
 use super::bigint::*;
-use crate::{ILimb, ULimb};
+use crate::{ILimb, IWide, ULimb, UWide};
 
 macro_rules! unsigned_define {
     (
-        $u:ty,wrapping_full =>
+        type =>
+        $u:ty,wide =>
+        $w:ty,wrapping_full =>
         $wrapping_full:ident,overflowing_full =>
         $overflowing_full:ident,wrapping_limb =>
         $wrapping_limb:ident,overflowing_limb =>
-        $overflowing_limb:ident,borrowing =>
+        $overflowing_limb:ident,wrapping_wide =>
+        $wrapping_wide:ident,overflowing_wide =>
+        $overflowing_wide:ident,wrapping_mn =>
+        $wrapping_mn:ident,overflowing_mn =>
+        $overflowing_mn:ident,borrowing =>
         $borrowing:ident $(,)?
     ) => {
         /// Const implementation of `wrapping_sub` for internal algorithm use.
@@ -200,42 +206,141 @@ macro_rules! unsigned_define {
 
             (result, c)
         }
+
+        /// Const implementation of `wrapping_sub` for internal algorithm use.
+        // NOTE: This differs significantly from `wrapping_full`.
+        #[inline]
+        pub const fn $wrapping_mn<const M: usize, const N: usize>(
+            x: &[$u; M],
+            y: &[$u; N],
+        ) -> [$u; M] {
+            assert!(N >= 2 && M > N);
+
+            let mut index = 0;
+            let mut result = [0; M];
+            let mut c: bool = false;
+            let mut vi: $u;
+
+            while index < N {
+                (vi, c) = $borrowing(ne_index!(x[index]), ne_index!(y[index]), c);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+
+            while index < M - 1 {
+                (vi, c) = ne_index!(x[index]).overflowing_sub(c as $u);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+            ne_index!(result[index] = ne_index!(x[index]).wrapping_sub(c as $u));
+
+            result
+        }
+
+        /// Const implementation of `overflowing_sub` for internal algorithm use.
+        // NOTE: This differs significantly from `overflowing_full`.
+        #[inline]
+        pub const fn $overflowing_mn<const M: usize, const N: usize>(
+            x: &[$u; M],
+            y: &[$u; N],
+        ) -> ([$u; M], bool) {
+            assert!(N >= 2 && M > N);
+
+            let mut index = 0;
+            let mut result = [0; M];
+            let mut c: bool = false;
+            let mut vi: $u;
+
+            while index < N {
+                (vi, c) = $borrowing(ne_index!(x[index]), ne_index!(y[index]), c);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+
+            while index < M {
+                (vi, c) = ne_index!(x[index]).overflowing_sub(c as $u);
+                ne_index!(result[index] = vi);
+                index += 1;
+            }
+
+            (result, c)
+        }
+
+        /// Const implementation of `wrapping_sub` a small number to the wider type.
+        #[inline]
+        pub const fn $wrapping_wide<const N: usize>(x: &[$u; N], y: $w) -> [$u; N] {
+            let mut rhs = [0; 2];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $wrapping_mn(x, &rhs)
+        }
+
+        /// Const implementation of `overflowing_sub` a small number to the wider type.
+        #[inline]
+        pub const fn $overflowing_wide<const N: usize>(x: &[$u; N], y: $w) -> ([$u; N], bool) {
+            let mut rhs = [0; 2];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $overflowing_mn(x, &rhs)
+        }
     };
 }
 
 unsigned_define!(
-    u32,
+    type => u32,
+    wide => u64,
     wrapping_full => wrapping_u32,
     overflowing_full => overflowing_u32,
     wrapping_limb => wrapping_limb_u32,
     overflowing_limb => overflowing_limb_u32,
+    wrapping_wide => wrapping_wide_u32,
+    overflowing_wide => overflowing_wide_u32,
+    wrapping_mn => wrapping_mn_u32,
+    overflowing_mn => overflowing_mn_u32,
     borrowing => borrowing_sub_u32,
 );
 unsigned_define!(
-    u64,
+    type => u64,
+    wide => u128,
     wrapping_full => wrapping_u64,
     overflowing_full => overflowing_u64,
     wrapping_limb => wrapping_limb_u64,
     overflowing_limb => overflowing_limb_u64,
+    wrapping_wide => wrapping_wide_u64,
+    overflowing_wide => overflowing_wide_u64,
+    wrapping_mn => wrapping_mn_u64,
+    overflowing_mn => overflowing_mn_u64,
     borrowing => borrowing_sub_u64,
 );
 
 limb_function!(wrapping_unsigned, wrapping_u64, wrapping_u32, &[ULimb; N], ret => [ULimb; N]);
 limb_function!(overflowing_unsigned, overflowing_u64, overflowing_u32, &[ULimb; N], &[ULimb; N], ret => ([ULimb; N], bool));
 
+// limb
 limb_function!(wrapping_limb, wrapping_limb_u64, wrapping_limb_u32, &[ULimb; N], ULimb, ret => [ULimb; N]);
 limb_function!(overflowing_limb, overflowing_limb_u64, overflowing_limb_u32, &[ULimb; N], ULimb, ret => ([ULimb; N], bool));
 
+// wide
+limb_function!(wrapping_wide, wrapping_wide_u64, wrapping_wide_u32, &[ULimb; N], UWide, ret => [ULimb; N]);
+limb_function!(overflowing_wide, overflowing_wide_u64, overflowing_wide_u32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
+
 macro_rules! signed_define {
     (
-        $u:ty,
-        $s:ty,wrapping_full =>
+        unsigned =>
+        $u:ty,signed =>
+        $s:ty,unsigned_wide =>
+        $uw:ty,signed_wide =>
+        $sw:ty,wrapping_full =>
         $wrapping_full:ident,overflowing_full =>
         $overflowing_full:ident,wrapping_ulimb =>
         $wrapping_ulimb:ident,overflowing_ulimb =>
         $overflowing_ulimb:ident,wrapping_ilimb =>
         $wrapping_ilimb:ident,overflowing_ilimb =>
-        $overflowing_ilimb:ident,borrowing =>
+        $overflowing_ilimb:ident,wrapping_uwide =>
+        $wrapping_uwide:ident,overflowing_uwide =>
+        $overflowing_uwide:ident,wrapping_iwide =>
+        $wrapping_iwide:ident,overflowing_iwide =>
+        $overflowing_iwide:ident,borrowing =>
         $borrowing:ident $(,)?
     ) => {
         /// Const implementation of `wrapping_sub` for internal algorithm use.
@@ -541,39 +646,94 @@ macro_rules! signed_define {
             ne_index!(rhs[0] = y as $u);
             $overflowing_full(x, &rhs)
         }
+
+        /// Const implementation to subtract a small, unsigned number to the wider type.
+        pub const fn $wrapping_uwide<const N: usize>(x: &[$u; N], y: $uw) -> [$u; N] {
+            let mut rhs = [0; N];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $wrapping_full(x, &rhs)
+        }
+
+        /// Const implementation to subtract a small, unsigned number to the wider type.
+        pub const fn $overflowing_uwide<const N: usize>(x: &[$u; N], y: $uw) -> ([$u; N], bool) {
+            let mut rhs = [0; N];
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $overflowing_full(x, &rhs)
+        }
+
+        /// Const implementation to subtract a small, signed number to the wider type.
+        pub const fn $wrapping_iwide<const N: usize>(x: &[$u; N], y: $sw) -> [$u; N] {
+            let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
+            let mut rhs = [sign_bit; N];
+            let y = y as $uw;
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $wrapping_full(x, &rhs)
+        }
+
+        /// Const implementation to subtract a small, signed number to the wider type.
+        pub const fn $overflowing_iwide<const N: usize>(x: &[$u; N], y: $sw) -> ([$u; N], bool) {
+            let sign_bit = <$u>::MIN.wrapping_sub(y.is_negative() as $u);
+            let mut rhs = [sign_bit; N];
+            let y = y as $uw;
+            ne_index!(rhs[0] = y as $u);
+            ne_index!(rhs[1] = (y >> <$u>::BITS) as $u);
+            $overflowing_full(x, &rhs)
+        }
     };
 }
 
 signed_define!(
-    u32,
-    i32,
+    unsigned => u32,
+    signed => i32,
+    unsigned_wide => u64,
+    signed_wide => i64,
     wrapping_full => wrapping_i32,
     overflowing_full => overflowing_i32,
     wrapping_ulimb => wrapping_ulimb_i32,
     overflowing_ulimb => overflowing_ulimb_i32,
     wrapping_ilimb => wrapping_ilimb_i32,
     overflowing_ilimb => overflowing_ilimb_i32,
+    wrapping_uwide => wrapping_uwide_i32,
+    overflowing_uwide => overflowing_uwide_i32,
+    wrapping_iwide => wrapping_iwide_i32,
+    overflowing_iwide => overflowing_iwide_i32,
     borrowing => borrowing_sub_u32,
 );
 signed_define!(
-    u64,
-    i64,
+    unsigned => u64,
+    signed => i64,
+    unsigned_wide => u128,
+    signed_wide => i128,
     wrapping_full => wrapping_i64,
     overflowing_full => overflowing_i64,
     wrapping_ulimb => wrapping_ulimb_i64,
     overflowing_ulimb => overflowing_ulimb_i64,
     wrapping_ilimb => wrapping_ilimb_i64,
     overflowing_ilimb => overflowing_ilimb_i64,
+    wrapping_uwide => wrapping_uwide_i64,
+    overflowing_uwide => overflowing_uwide_i64,
+    wrapping_iwide => wrapping_iwide_i64,
+    overflowing_iwide => overflowing_iwide_i64,
     borrowing => borrowing_sub_u64,
 );
 
 limb_function!(wrapping_signed, wrapping_i64, wrapping_i32, &[ULimb; N], ret => [ULimb; N]);
 limb_function!(overflowing_signed, overflowing_i64, overflowing_i32, &[ULimb; N], &[ULimb; N], ret => ([ULimb; N], bool));
 
+// limb
 limb_function!(wrapping_ulimb, wrapping_ulimb_i64, wrapping_ulimb_i32, &[ULimb; N], ULimb, ret => [ULimb; N]);
 limb_function!(wrapping_ilimb, wrapping_ilimb_i64, wrapping_ilimb_i32, &[ULimb; N], ILimb, ret => [ULimb; N]);
 limb_function!(overflowing_ulimb, overflowing_ulimb_i64, overflowing_ulimb_i32, &[ULimb; N], ULimb, ret => ([ULimb; N], bool));
 limb_function!(overflowing_ilimb, overflowing_ilimb_i64, overflowing_ilimb_i32, &[ULimb; N], ILimb, ret => ([ULimb; N], bool));
+
+// wide
+limb_function!(wrapping_uwide, wrapping_uwide_i64, wrapping_uwide_i32, &[ULimb; N], UWide, ret => [ULimb; N]);
+limb_function!(wrapping_iwide, wrapping_iwide_i64, wrapping_iwide_i32, &[ULimb; N], IWide, ret => [ULimb; N]);
+limb_function!(overflowing_uwide, overflowing_uwide_i64, overflowing_uwide_i32, &[ULimb; N], UWide, ret => ([ULimb; N], bool));
+limb_function!(overflowing_iwide, overflowing_iwide_i64, overflowing_iwide_i32, &[ULimb; N], IWide, ret => ([ULimb; N], bool));
 
 #[cfg(test)]
 mod tests {

--- a/src/shared/bigint.rs
+++ b/src/shared/bigint.rs
@@ -4,7 +4,10 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (wide_type => $wide_t:ty) => {
+    (
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Calculates `self` + `rhs` + `carry` and returns a tuple containing
         /// the sum and the output carry.
         ///
@@ -13,7 +16,7 @@ macro_rules! define {
         /// chaining together multiple additions to create a wider addition, and
         /// can be useful for bignum addition.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, carrying_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, carrying_add)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -32,7 +35,7 @@ macro_rules! define {
         /// subtractions to create a wider subtraction, and can be useful for
         /// bignum subtraction.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, borrowing_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, borrowing_sub)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline]
         #[must_use]

--- a/src/shared/bitops.rs
+++ b/src/shared/bitops.rs
@@ -5,10 +5,14 @@
 /// See the bench on `bit_algos` for some of the choices.
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Returns the number of ones in the binary representation of `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::count_ones`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, count_ones)]
         #[inline(always)]
         pub const fn count_ones(self) -> u32 {
             // NOTE: Rust vectorizes this nicely on x86_64.
@@ -23,7 +27,7 @@ macro_rules! define {
 
         /// Returns the number of zeros in the binary representation of `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::count_zeros`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, count_zeros)]
         #[inline(always)]
         pub const fn count_zeros(self) -> u32 {
             self.not_const().count_ones()
@@ -53,7 +57,7 @@ macro_rules! define {
         /// assert_eq!(max.leading_zeros(), 1);
         /// ```
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::leading_zeros`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, leading_zeros)]
         #[inline]
         pub const fn leading_zeros(self) -> u32 {
             let mut count = 0;
@@ -68,7 +72,7 @@ macro_rules! define {
         /// Returns the number of trailing zeros in the binary representation of
         /// `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::trailing_zeros`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, trailing_zeros)]
         #[inline]
         pub const fn trailing_zeros(self) -> u32 {
             let mut count = 0;
@@ -83,7 +87,7 @@ macro_rules! define {
         /// Returns the number of leading ones in the binary representation of
         /// `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::leading_ones`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, leading_ones)]
         #[inline(always)]
         pub const fn leading_ones(self) -> u32 {
             self.not_const().leading_zeros()
@@ -92,7 +96,7 @@ macro_rules! define {
         /// Returns the number of trailing ones in the binary representation of
         /// `self`.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::trailing_ones`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, trailing_ones)]
         #[inline(always)]
         pub const fn trailing_ones(self) -> u32 {
             self.not_const().trailing_zeros()
@@ -160,7 +164,7 @@ macro_rules! define {
         ///
         /// Please note this isn't the same operation as the `<<` shifting operator!
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::rotate_left`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, rotate_left)]
         #[inline(always)]
         pub const fn rotate_left(self, n: u32) -> Self {
             let result = $crate::math::rotate::left_wide(self.to_ne_wide(), n);
@@ -173,7 +177,7 @@ macro_rules! define {
         ///
         /// Please note this isn't the same operation as the `>>` shifting operator!
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::rotate_right`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, rotate_right)]
         #[inline(always)]
         pub const fn rotate_right(self, n: u32) -> Self {
             let result = $crate::math::rotate::right_wide(self.to_ne_wide(), n);

--- a/src/shared/casts.rs
+++ b/src/shared/casts.rs
@@ -177,7 +177,12 @@ macro_rules! define {
             const BITS: u32 = $crate::ULimb::BITS;
             assert!(BITS == 32 || BITS == 64);
             if BITS == 32 {
-                Self::from_i32(value as i32)
+                let sign_bit = $crate::ULimb::MIN.wrapping_sub(value.is_negative() as $crate::ULimb);
+                let mut limbs = [sign_bit; Self::LIMBS];
+                let value = value as $crate::UWide;
+                ne_index!(limbs[0] = value as $crate::ULimb);
+                ne_index!(limbs[1] = (value >> 32) as $crate::ULimb);
+                Self::from_ne_limbs(limbs)
             } else {
                 let sign_bit = $crate::ULimb::MIN.wrapping_sub(value.is_negative() as $crate::ULimb);
                 let mut limbs = [sign_bit; Self::LIMBS];

--- a/src/shared/checked.rs
+++ b/src/shared/checked.rs
@@ -2,11 +2,15 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Checked integer addition. Computes `self + rhs`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_add)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add(self, rhs: Self) -> Option<Self> {
@@ -21,7 +25,7 @@ macro_rules! define {
         /// Checked integer subtraction. Computes `self - rhs`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_sub)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub(self, rhs: Self) -> Option<Self> {
@@ -36,7 +40,7 @@ macro_rules! define {
         /// Checked integer multiplication. Computes `self * rhs`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_mul)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul(self, rhs: Self) -> Option<Self> {
@@ -61,7 +65,7 @@ macro_rules! define {
         /// Checked exponentiation. Computes `self.pow(exp)`, returning `None`
         /// if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_pow)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_pow(self, base: u32) -> Option<Self> {
@@ -89,7 +93,7 @@ macro_rules! define {
         /// Checked integer division. Computes `self / rhs`, returning `None`
         /// `rhs == 0` or the division results in overflow (signed only).
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_div)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div(self, rhs: Self) -> Option<Self> {
@@ -103,7 +107,7 @@ macro_rules! define {
         /// Checked integer division. Computes `self % rhs`, returning `None`
         /// `rhs == 0` or the division results in overflow (signed only).
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_rem)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem(self, rhs: Self) -> Option<Self> {
@@ -118,7 +122,7 @@ macro_rules! define {
         /// returning `None` if `rhs == 0` or the division results in
         /// overflow (signed only).
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_div_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_euclid(self, rhs: Self) -> Option<Self> {
@@ -133,7 +137,7 @@ macro_rules! define {
         /// returning `None` if `rhs == 0` or the division results in
         /// overflow (signed only).
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_rem_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_euclid(self, rhs: Self) -> Option<Self> {
@@ -147,7 +151,7 @@ macro_rules! define {
         /// Checked shift left. Computes `self << rhs`, returning `None` if `rhs` is
         /// larger than or equal to the number of bits in `self`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_shl)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_shl)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_shl(self, rhs: u32) -> Option<Self> {
@@ -162,7 +166,7 @@ macro_rules! define {
         /// Checked shift right. Computes `self >> rhs`, returning `None` if `rhs`
         /// is larger than or equal to the number of bits in `self`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_shr)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_shr)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_shr(self, rhs: u32) -> Option<Self> {
@@ -178,7 +182,7 @@ macro_rules! define {
         ///
         /// Returns `None` if the number is negative or zero.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, checked_ilog2)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_ilog2)]
         #[inline(always)]
         pub const fn checked_ilog2(self) -> Option<u32> {
             match self.le_const(Self::from_u8(0)) {

--- a/src/shared/constants.rs
+++ b/src/shared/constants.rs
@@ -3,22 +3,22 @@
 #[rustfmt::skip]
 macro_rules! define {
     (
-        bits =>
-        $bits:expr,wide_type =>
-        $wide_t:ty,low_type =>
-        $lo_t:ty,high_type =>
-        $hi_t:ty $(,)?
+        bits => $bits:expr,
+        wide_type => $wide_t:ty,
+        low_type => $lo_t:ty,
+        high_type => $hi_t:ty,
+        see_type => $see_t:ty $(,)?
     ) => {
         /// The smallest value that can be represented by this integer type.
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::MIN`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, MIN)]
         #[allow(deprecated)]
         pub const MIN: Self = Self::min_value();
 
         /// The largest value that can be represented by this integer type
         /// (2<sup>256</sup> - 1).
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::MAX`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, MAX)]
         #[allow(deprecated)]
         pub const MAX: Self = Self::max_value();
 
@@ -31,7 +31,7 @@ macro_rules! define {
         /// assert_eq!(u256::BITS, 256);
         /// ```
         ///
-        #[doc = concat!("See [`", stringify!($wide_t), "::BITS`].")]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, BITS)]
         pub const BITS: u32 = $bits;
 
         // Internal use only

--- a/src/shared/docs.rs
+++ b/src/shared/docs.rs
@@ -114,7 +114,16 @@ pub(crate) use overflow_assertions_doc;
 #[rustfmt::skip]
 macro_rules! limb_doc {
     ($op:ident) => {
-        concat!("This allows optimizations a full ", stringify!($op), " cannot do.")
+        concat!(
+"
+This allows optimizations a full ", stringify!($op), " cannot do.
+
+Please note that the size of [`ULimb`] depends on the target architecture and
+can be 64 or 128 bits large. If you need support for scalars of a guaranteed
+width, use the `*_u32`, `_u64`, and `_u128` APIs instead, such as
+[`u256::add_u32`] (requires the `stdint` feature).
+"
+)
     };
 }
 
@@ -129,6 +138,11 @@ This allows may allows optimizations a full ", stringify!($op), " cannot do.
 However, performance can be highly variable and you should always benchmark
 your results. A full description of the performance tradeoffs with wide types
 can be found in the documentation for [`UWide`][crate::UWide].
+
+Please note that the size of [`UWide`] depends on the target architecture and
+can be 64 or 128 bits large. If you need support for scalars of a guaranteed
+width, use the `*_u32`, `_u64`, and `_u128` APIs instead, such as
+[`u256::add_u32`] (requires the `stdint` feature).
 "
         )
     };

--- a/src/shared/docs.rs
+++ b/src/shared/docs.rs
@@ -152,7 +152,11 @@ pub(crate) use wide_doc;
 
 #[rustfmt::skip]
 macro_rules! as_cast_doc {
-    ($bits:literal, $kind:ident, $to:expr) => {
+    (
+        $bits:literal,
+        $kind:ident,
+        $to:expr $(,)?
+    ) => {
         concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " integer to ", $to, ", as if by an `as` cast.")
     };
 }
@@ -161,7 +165,11 @@ pub(crate) use as_cast_doc;
 
 #[rustfmt::skip]
 macro_rules! from_cast_doc {
-    ($bits:literal, $kind:ident, $to:expr) => {
+    (
+        $bits:literal,
+        $kind:ident,
+        $to:expr $(,)?
+    ) => {
         concat!("Create the ", stringify!($bits), "-bit ", stringify!($kind), " integer from ", $to, ", as if by an `as` cast.")
     };
 }

--- a/src/shared/docs.rs
+++ b/src/shared/docs.rs
@@ -121,6 +121,22 @@ macro_rules! limb_doc {
 pub(crate) use limb_doc;
 
 #[rustfmt::skip]
+macro_rules! wide_doc {
+    ($op:ident) => {
+        concat!(
+"
+This allows may allows optimizations a full ", stringify!($op), " cannot do.
+However, performance can be highly variable and you should always benchmark
+your results. A full description of the performance tradeoffs with wide types
+can be found in the documentation for [`UWide`][crate::UWide].
+"
+        )
+    };
+}
+
+pub(crate) use wide_doc;
+
+#[rustfmt::skip]
 macro_rules! as_cast_doc {
     ($bits:literal, $kind:ident, $to:expr) => {
         concat!("Convert the ", stringify!($bits), "-bit ", stringify!($kind), " integer to ", $to, ", as if by an `as` cast.")

--- a/src/shared/endian.rs
+++ b/src/shared/endian.rs
@@ -46,7 +46,7 @@ macro_rules! define {
                 limbs: [0; Self::LIMBS],
             };
             let mut i = 0;
-            while i < 4 {
+            while i < Self::LIMBS {
                 r.limbs[i] = self.limbs[Self::LIMBS - 1 - i].reverse_bits();
                 i += 1;
             }

--- a/src/shared/endian.rs
+++ b/src/shared/endian.rs
@@ -2,7 +2,11 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// The number of bytes in the type.
         const BYTES: usize = Self::BITS as usize / 8;
         const U32_LEN: usize = Self::BYTES / 4;
@@ -15,7 +19,7 @@ macro_rules! define {
         /// This optimizes very nicely, with efficient `bswap` or `rol`
         /// implementations for each.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, swap_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, swap_bytes)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn swap_bytes(&self) -> Self {
@@ -34,7 +38,7 @@ macro_rules! define {
         /// bit becomes the most significant bit, second least-significant bit
         /// becomes second most-significant bit, etc.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, reverse_bits)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, reverse_bits)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn reverse_bits(&self) -> Self {
@@ -54,7 +58,7 @@ macro_rules! define {
         /// On big endian this is a no-op. On little endian the bytes are
         /// swapped.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_be)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, from_be)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be(x: Self) -> Self {
@@ -70,7 +74,7 @@ macro_rules! define {
         /// On little endian this is a no-op. On big endian the bytes are
         /// swapped.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_le)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, from_le)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le(x: Self) -> Self {
@@ -86,7 +90,7 @@ macro_rules! define {
         /// On big endian this is a no-op. On little endian the bytes are
         /// swapped.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_be)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, to_be)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be(self) -> Self {
@@ -102,7 +106,7 @@ macro_rules! define {
         /// On little endian this is a no-op. On big endian the bytes are
         /// swapped.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_le)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, to_le)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le(self) -> Self {
@@ -116,7 +120,7 @@ macro_rules! define {
         /// Returns the memory representation of this integer as a byte array in
         /// big-endian (network) byte order.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_be_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, to_be_bytes)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_be_bytes(self) -> [u8; Self::BYTES] {
@@ -126,7 +130,7 @@ macro_rules! define {
         /// Returns the memory representation of this integer as a byte array in
         /// little-endian byte order.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_le_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, to_le_bytes)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn to_le_bytes(self) -> [u8; Self::BYTES] {
@@ -140,7 +144,7 @@ macro_rules! define {
         /// should use [`to_be_bytes`] or [`to_le_bytes`], as appropriate,
         /// instead.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, to_ne_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, to_ne_bytes)]
         ///
         /// [`to_be_bytes`]: Self::to_be_bytes
         /// [`to_le_bytes`]: Self::to_le_bytes
@@ -156,7 +160,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as a byte array in big endian.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_be_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, from_be_bytes)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_be_bytes(bytes: [u8; Self::BYTES]) -> Self {
@@ -166,7 +170,7 @@ macro_rules! define {
         /// Creates a native endian integer value from its representation
         /// as a byte array in little endian.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_le_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, from_le_bytes)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn from_le_bytes(bytes: [u8; Self::BYTES]) -> Self {
@@ -180,7 +184,7 @@ macro_rules! define {
         /// likely wants to use [`from_be_bytes`] or [`from_le_bytes`], as
         /// appropriate instead.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, from_ne_bytes)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, from_ne_bytes)]
         ///
         /// [`from_be_bytes`]: Self::from_be_bytes
         /// [`from_le_bytes`]: Self::from_le_bytes

--- a/src/shared/extensions.rs
+++ b/src/shared/extensions.rs
@@ -1,7 +1,7 @@
 //! Custom integer extensions for ergonomics.
 
 macro_rules! define {
-    (high_type => $hi_t:ty) => {
+    (high_type => $hi_t:ty $(,)?) => {
         /// Get if the integer is even.
         #[inline(always)]
         pub const fn is_even(&self) -> bool {

--- a/src/shared/limb.rs
+++ b/src/shared/limb.rs
@@ -179,10 +179,98 @@ macro_rules! define {
         pub fn rem_uwide(self, n: $crate::UWide) -> $crate::UWide {
             self.div_rem_uwide(n).1
         }
+    };
+
+    (fixed) => {
 
         // U32
 
-        // TODO: Add
+        /// Add [`u32`] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_u32(self, n: u32) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_u32(n)
+            } else {
+                match self.checked_add_u32(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`u32`] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_u32(self, n: u32) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_u32(n)
+            } else {
+                match self.checked_sub_u32(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`u32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_u32(self, n: u32) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_u32(n)
+            } else {
+                match self.checked_mul_u32(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        ///
+        /// # Panics
+        ///
+        /// This panics if the divisor is 0.
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_u32(self, n: u32) -> (Self, u32) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_u32(n)
+            } else {
+                match self.checked_div_rem_u32(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`u32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_u32(self, n: u32) -> Self {
+            self.div_rem_u32(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`u32`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_u32(self, n: u32) -> u32 {
+            self.div_rem_u32(n).1
+        }
 
         // U64
 
@@ -237,6 +325,9 @@ macro_rules! define {
         pub fn wrapping_rem_uwide(self, n: $crate::UWide) -> $crate::UWide {
             self.wrapping_div_rem_uwide(n).1
         }
+    };
+
+    (@wrapping-fixed) => {
 
         // U32
 
@@ -341,7 +432,9 @@ macro_rules! define {
             let (value, overflowed) = self.overflowing_div_rem_uwide(n);
             (value.1, overflowed)
         }
+    };
 
+    (@overflowing-fixed) => {
         // U32
 
         /// Get the quotient and remainder of our big integer divided
@@ -541,7 +634,9 @@ macro_rules! define {
         pub fn checked_rem_uwide(self, n: $crate::UWide) -> Option<$crate::UWide> {
             Some(self.checked_div_rem_uwide(n)?.1)
         }
+    };
 
+    (@checked-fixed) => {
         // U32
 
         /// Add [`u32`] to the big integer, returning None on overflow.
@@ -633,6 +728,15 @@ macro_rules! define {
         $crate::shared::limb::define!(@wrapping);
         $crate::shared::limb::define!(@overflowing);
         $crate::shared::limb::define!(@checked);
+
+        #[cfg(feature = "stdint")]
+        $crate::shared::limb::define!(fixed);
+        #[cfg(feature = "stdint")]
+        $crate::shared::limb::define!(@wrapping-fixed);
+        #[cfg(feature = "stdint")]
+        $crate::shared::limb::define!(@overflowing-fixed);
+        #[cfg(feature = "stdint")]
+        $crate::shared::limb::define!(@checked-fixed);
     };
 }
 

--- a/src/shared/limb.rs
+++ b/src/shared/limb.rs
@@ -274,11 +274,181 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`u64`] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_u64(self, n: u64) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_u64(n)
+            } else {
+                match self.checked_add_u64(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`u64`] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_u64(self, n: u64) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_u64(n)
+            } else {
+                match self.checked_sub_u64(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`u64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_u64(self, n: u64) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_u64(n)
+            } else {
+                match self.checked_mul_u64(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        ///
+        /// # Panics
+        ///
+        /// This panics if the divisor is 0.
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_u64(self, n: u64) -> (Self, u64) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_u64(n)
+            } else {
+                match self.checked_div_rem_u64(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`u64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_u64(self, n: u64) -> Self {
+            self.div_rem_u64(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`u64`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_u64(self, n: u64) -> u64 {
+            self.div_rem_u64(n).1
+        }
 
         // U128
 
-        // TODO: Add
+         /// Add [`u128`] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_u128(self, n: u128) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_u128(n)
+            } else {
+                match self.checked_add_u128(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`u128`] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_u128(self, n: u128) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_u128(n)
+            } else {
+                match self.checked_sub_u128(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`u128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_u128(self, n: u128) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_u128(n)
+            } else {
+                match self.checked_mul_u128(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        ///
+        /// # Panics
+        ///
+        /// This panics if the divisor is 0.
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_u128(self, n: u128) -> (Self, u128) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_u128(n)
+            } else {
+                match self.checked_div_rem_u128(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`u128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_u128(self, n: u128) -> Self {
+            self.div_rem_u128(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`u128`].
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_u128(self, n: u128) -> u128 {
+            self.div_rem_u128(n).1
+        }
     };
 
     (@wrapping) => {
@@ -353,11 +523,47 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Get the quotient of our big integer divided by [`u64`],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_u64(self, n: u64) -> Self {
+            self.wrapping_div_rem_u64(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`u64`],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_u64(self, n: u64) -> u64 {
+            self.wrapping_div_rem_u64(n).1
+        }
 
         // U128
 
-        // TODO: Add
+        /// Get the quotient of our big integer divided by [`u128`],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_u128(self, n: u128) -> Self {
+            self.wrapping_div_rem_u128(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`u128`],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_u128(self, n: u128) -> u128 {
+            self.wrapping_div_rem_u128(n).1
+        }
     };
 
     (@overflowing) => {
@@ -473,11 +679,75 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u64`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        pub fn overflowing_div_rem_u64(self, n: u64) -> ((Self, u64), bool) {
+            (self.wrapping_div_rem_u64(n), false)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`u64`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_u64(self, n: u64) -> (Self, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_u64(n);
+            (value.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`u64`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_u64(self, n: u64) -> (u64, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_u64(n);
+            (value.1, overflowed)
+        }
 
         // U128
 
-        // TODO: Add
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u128`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        pub fn overflowing_div_rem_u128(self, n: u128) -> ((Self, u128), bool) {
+            (self.wrapping_div_rem_u128(n), false)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`u128`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_u128(self, n: u128) -> (Self, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_u128(n);
+            (value.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`u128`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_u128(self, n: u128) -> (u128, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_u128(n);
+            (value.1, overflowed)
+        }
     };
 
     (@checked) => {
@@ -716,11 +986,157 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`u64`] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_u64(self, n: u64) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_u64(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`u64`] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_u64(self, n: u64) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_u64(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`u64`], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_u64(self, n: u64) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_u64(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        pub fn checked_div_rem_u64(self, n: u64) -> Option<(Self, u64)> {
+            if n == 0 {
+                None
+            } else {
+                Some(self.wrapping_div_rem_u64(n))
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_u64(self, n: u64) -> Option<Self> {
+            Some(self.checked_div_rem_u64(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_u64(self, n: u64) -> Option<u64> {
+            Some(self.checked_div_rem_u64(n)?.1)
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`u128`] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_u128(self, n: u128) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_u128(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`u128`] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_u128(self, n: u128) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_u128(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`u128`], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_u128(self, n: u128) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_u128(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        pub fn checked_div_rem_u128(self, n: u128) -> Option<(Self, u128)> {
+            if n == 0 {
+                None
+            } else {
+                Some(self.wrapping_div_rem_u128(n))
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_u128(self, n: u128) -> Option<Self> {
+            Some(self.checked_div_rem_u128(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_u128(self, n: u128) -> Option<u128> {
+            Some(self.checked_div_rem_u128(n)?.1)
+        }
     };
 
     (@all) => {

--- a/src/shared/limb.rs
+++ b/src/shared/limb.rs
@@ -2,7 +2,9 @@
 
 macro_rules! define {
     () => {
-        /// Add an unsigned limb to the big integer.
+        // LIMB
+
+        /// Add [`ULimb`][crate::ULimb] to the big integer.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -18,7 +20,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract an unsigned limb from the big integer.
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
@@ -34,7 +36,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by an unsigned limb.
+        /// Multiply our big integer by [`ULimb`][crate::ULimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
@@ -51,7 +53,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by an unsigned limb.
+        /// by [`ULimb`][crate::ULimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         ///
@@ -71,7 +73,7 @@ macro_rules! define {
             }
         }
 
-        /// Get the quotient of our big integer divided by an unsigned limb.
+        /// Get the quotient of our big integer divided by [`ULimb`][crate::ULimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -80,7 +82,7 @@ macro_rules! define {
             self.div_rem_ulimb(n).0
         }
 
-        /// Get the remainder of our big integer divided by an unsigned limb.
+        /// Get the remainder of our big integer divided by [`ULimb`][crate::ULimb].
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -88,10 +90,113 @@ macro_rules! define {
         pub fn rem_ulimb(self, n: $crate::ULimb) -> $crate::ULimb {
             self.div_rem_ulimb(n).1
         }
+
+        // WIDE
+
+        /// Add [`UWide`][crate::UWide] to the big integer.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn add_uwide(self, n: $crate::UWide) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_add_uwide(n)
+            } else {
+                match self.checked_add_uwide(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to add with overflow"),
+                }
+            }
+        }
+
+        /// Subtract [`UWide`][crate::UWide] from the big integer.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn sub_uwide(self, n: $crate::UWide) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_sub_uwide(n)
+            } else {
+                match self.checked_sub_uwide(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to subtract with overflow"),
+                }
+            }
+        }
+
+        /// Multiply our big integer by [`UWide`][crate::UWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn mul_uwide(self, n: $crate::UWide) -> Self {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_mul_uwide(n)
+            } else {
+                match self.checked_mul_uwide(n) {
+                    Some(v) => v,
+                    None => core::panic!("attempt to multiply with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`UWide`][crate::UWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        ///
+        /// # Panics
+        ///
+        /// This panics if the divisor is 0.
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_rem_uwide(self, n: $crate::UWide) -> (Self, $crate::UWide) {
+            if cfg!(not(have_overflow_checks)) {
+                self.wrapping_div_rem_uwide(n)
+            } else {
+                match self.checked_div_rem_uwide(n) {
+                    Some(v) => v,
+                    _ => core::panic!("attempt to divide with overflow"),
+                }
+            }
+        }
+
+        /// Get the quotient of our big integer divided by [`UWide`][crate::UWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn div_uwide(self, n: $crate::UWide) -> Self {
+            self.div_rem_uwide(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`UWide`][crate::UWide].
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn rem_uwide(self, n: $crate::UWide) -> $crate::UWide {
+            self.div_rem_uwide(n).1
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@wrapping) => {
-        /// Get the quotient of our big integer divided by an unsigned limb,
+        // LIMB
+
+        /// Get the quotient of our big integer divided by [`ULimb`][crate::ULimb],
         /// wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -101,7 +206,7 @@ macro_rules! define {
             self.wrapping_div_rem_ulimb(n).0
         }
 
-        /// Get the remainder of our big integer divided by an unsigned limb,
+        /// Get the remainder of our big integer divided by [`ULimb`][crate::ULimb],
         /// wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -110,11 +215,47 @@ macro_rules! define {
         pub fn wrapping_rem_ulimb(self, n: $crate::ULimb) -> $crate::ULimb {
             self.wrapping_div_rem_ulimb(n).1
         }
+
+        // WIDE
+
+        /// Get the quotient of our big integer divided by [`UWide`][crate::UWide],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_uwide(self, n: $crate::UWide) -> Self {
+            self.wrapping_div_rem_uwide(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`UWide`][crate::UWide],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_uwide(self, n: $crate::UWide) -> $crate::UWide {
+            self.wrapping_div_rem_uwide(n).1
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@overflowing) => {
+        // LIMB
+
         /// Get the quotient and remainder of our big integer divided
-        /// by an unsigned limb, returning the value and if overflow
+        /// by [`ULimb`][crate::ULimb], returning the value and if overflow
         /// occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -124,7 +265,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided
-        /// by an unsigned limb, returning the value and if overflow
+        /// by [`ULimb`][crate::ULimb], returning the value and if overflow
         /// occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -136,7 +277,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided
-        /// by an unsigned limb, returning the value and if overflow
+        /// by [`ULimb`][crate::ULimb], returning the value and if overflow
         /// occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
@@ -146,10 +287,60 @@ macro_rules! define {
             let (value, overflowed) = self.overflowing_div_rem_ulimb(n);
             (value.1, overflowed)
         }
+
+        // WIDE
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`UWide`][crate::UWide], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline]
+        pub fn overflowing_div_rem_uwide(self, n: $crate::UWide) -> ((Self, $crate::UWide), bool) {
+            (self.wrapping_div_rem_uwide(n), false)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`UWide`][crate::UWide], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_uwide(n);
+            (value.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`UWide`][crate::UWide], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_uwide(self, n: $crate::UWide) -> ($crate::UWide, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_uwide(n);
+            (value.1, overflowed)
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@checked) => {
-        /// Add an unsigned limb to the big integer, returning None on overflow.
+        // LIMB
+
+        /// Add [`ULimb`][crate::ULimb] to the big integer, returning None on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -163,7 +354,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract an unsigned limb from the big integer, returning None on overflow.
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer, returning None on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -177,7 +368,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by an unsigned limb, returning None on overflow.
+        /// Multiply our big integer by [`ULimb`][crate::ULimb], returning None on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
@@ -223,6 +414,95 @@ macro_rules! define {
         pub fn checked_rem_ulimb(self, n: $crate::ULimb) -> Option<$crate::ULimb> {
             Some(self.checked_div_rem_ulimb(n)?.1)
         }
+
+        // WIDE
+
+        /// Add [`UWide`][crate::UWide] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_uwide(self, n: $crate::UWide) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_uwide(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`UWide`][crate::UWide] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_uwide(self, n: $crate::UWide) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_uwide(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`UWide`][crate::UWide], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_uwide(self, n: $crate::UWide) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_uwide(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline]
+        pub fn checked_div_rem_uwide(self, n: $crate::UWide) -> Option<(Self, $crate::UWide)> {
+            if n == 0 {
+                None
+            } else {
+                Some(self.wrapping_div_rem_uwide(n))
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_uwide(self, n: $crate::UWide) -> Option<Self> {
+            Some(self.checked_div_rem_uwide(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_uwide(self, n: $crate::UWide) -> Option<$crate::UWide> {
+            Some(self.checked_div_rem_uwide(n)?.1)
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@all) => {

--- a/src/shared/limb.rs
+++ b/src/shared/limb.rs
@@ -240,7 +240,25 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Get the quotient of our big integer divided by [`u32`],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_u32(self, n: u32) -> Self {
+            self.wrapping_div_rem_u32(n).0
+        }
+
+        /// Get the remainder of our big integer divided by [`u32`],
+        /// wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_rem_u32(self, n: u32) -> u32 {
+            self.wrapping_div_rem_u32(n).1
+        }
 
         // U64
 
@@ -326,7 +344,39 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u32`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        pub fn overflowing_div_rem_u32(self, n: u32) -> ((Self, u32), bool) {
+            (self.wrapping_div_rem_u32(n), false)
+        }
+
+        /// Get the quotient of our big integer divided
+        /// by [`u32`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_div_u32(self, n: u32) -> (Self, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_u32(n);
+            (value.0, overflowed)
+        }
+
+        /// Get the remainder of our big integer divided
+        /// by [`u32`], returning the value and if overflow
+        /// occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn overflowing_rem_u32(self, n: u32) -> (u32, bool) {
+            let (value, overflowed) = self.overflowing_div_rem_u32(n);
+            (value.1, overflowed)
+        }
 
         // U64
 
@@ -494,7 +544,80 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`u32`] to the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_add_u32(self, n: u32) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_add_u32(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Subtract [`u32`] from the big integer, returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_sub_u32(self, n: u32) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_sub_u32(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Multiply our big integer by [`u32`], returning None on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn checked_mul_u32(self, n: u32) -> Option<Self> {
+            let (value, overflowed) = self.overflowing_mul_u32(n);
+            if overflowed {
+                None
+            } else {
+                Some(value)
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline]
+        pub fn checked_div_rem_u32(self, n: u32) -> Option<(Self, u32)> {
+            if n == 0 {
+                None
+            } else {
+                Some(self.wrapping_div_rem_u32(n))
+            }
+        }
+
+        /// Get the quotient of our big integer divided by an unsigned
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_div_u32(self, n: u32) -> Option<Self> {
+            Some(self.checked_div_rem_u32(n)?.0)
+        }
+
+        /// Get the remainder of our big integer divided by a signed
+        /// limb, returning None on overflow or division by 0.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn checked_rem_u32(self, n: u32) -> Option<u32> {
+            Some(self.checked_div_rem_u32(n)?.1)
+        }
 
         // U64
 

--- a/src/shared/ops.rs
+++ b/src/shared/ops.rs
@@ -8,10 +8,14 @@
 /// as well as `div_euclid` and `rem_euclid` to be defined.
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Raises self to the power of `exp`, using exponentiation by squaring.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, pow)]
         #[inline]
         pub const fn pow(self, exp: u32) -> Self {
             if cfg!(not(have_overflow_checks)) {

--- a/src/shared/ord.rs
+++ b/src/shared/ord.rs
@@ -27,7 +27,12 @@ macro_rules! define {
             i -= 1;
             let lhs_i = ne_index!(lhs[i]) as $lo_t;
             let rhs_i = ne_index!(rhs[i]) as $lo_t;
-            is_ord = lhs_i $op2 rhs_i;
+            // NOTE: `<=/>=` OP only should be done in the last loop
+            is_ord = if i == 0 {
+                lhs_i $op2 rhs_i
+            } else {
+                lhs_i $op1 rhs_i
+            };
             is_eq = lhs_i == rhs_i;
         }
         is_ord

--- a/src/shared/ord.rs
+++ b/src/shared/ord.rs
@@ -37,7 +37,7 @@ macro_rules! define {
         low_type => $lo_t:ty,
         high_type => $hi_t:ty $(,)?
     ) => {
-        /// Non-short circuiting const implementation of `Eq`.
+        /// Non-short circuiting const implementation of [`Eq`].
         #[inline(always)]
         const fn eq_branchless(self, rhs: Self) -> bool {
             let lhs = self.to_ne_wide();
@@ -52,7 +52,7 @@ macro_rules! define {
             is_eq
         }
 
-        /// Short-circuiting const implementation of `Eq`.
+        /// Short-circuiting const implementation of [`Eq`].
         #[inline(always)]
         pub const fn eq_branched(self, rhs: Self) -> bool {
             let lhs = self.to_ne_wide();
@@ -66,7 +66,7 @@ macro_rules! define {
             is_eq
         }
 
-        /// Non-short circuiting const implementation of `Eq`.
+        /// Non-short circuiting const implementation of [`Eq`].
         #[inline(always)]
         pub const fn eq_const(self, rhs: Self) -> bool {
             if Self::BITS < 4096 {
@@ -80,8 +80,9 @@ macro_rules! define {
         // This can always be implemented in terms of the highest wide bit, then the
         // rest as low.
 
-        /// Non-short circuiting const implementation of `PartialOrd::lt`.
+        /// Non-short circuiting const implementation of [`PartialOrd::lt`].
         #[inline(always)]
+        #[must_use]
         pub const fn lt_const(self, rhs: Self) -> bool {
             $crate::shared::ord::define!(
                 @ord
@@ -94,7 +95,8 @@ macro_rules! define {
             )
         }
 
-        /// Non-short circuiting const implementation of `PartialOrd::le`.
+        /// Non-short circuiting const implementation of [`PartialOrd::le`].
+        #[must_use]
         #[inline(always)]
         pub const fn le_const(self, rhs: Self) -> bool {
             $crate::shared::ord::define!(
@@ -108,19 +110,19 @@ macro_rules! define {
             )
         }
 
-        /// Non-short circuiting const implementation of `PartialOrd::gt`.
+        /// Non-short circuiting const implementation of [`PartialOrd::gt`].
         #[inline(always)]
         pub const fn gt_const(self, rhs: Self) -> bool {
             !self.le_const(rhs)
         }
 
-        /// Non-short circuiting const implementation of `PartialOrd::ge`.
+        /// Non-short circuiting const implementation of [`PartialOrd::ge`].
         #[inline(always)]
         pub const fn ge_const(self, rhs: Self) -> bool {
             !self.lt_const(rhs)
         }
 
-        /// Non-short circuiting const implementation of `PartialOrd::cmp`.
+        /// Non-short circuiting const implementation of [`Ord::cmp`].
         #[inline(always)]
         pub const fn cmp_const(self, rhs: Self) -> core::cmp::Ordering {
             let lhs = self.to_ne_wide();
@@ -156,7 +158,7 @@ macro_rules! define {
 pub(crate) use define;
 
 macro_rules! traits {
-    ($t:ty) => {
+    ($t:ty $(,)?) => {
         impl core::cmp::Ord for $t {
             #[inline(always)]
             fn cmp(&self, other: &Self) -> core::cmp::Ordering {

--- a/src/shared/overflowing.rs
+++ b/src/shared/overflowing.rs
@@ -2,14 +2,18 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Raises self to the power of `exp`, using exponentiation by squaring,
         /// returning the value.
         ///
         /// Returns a tuple of the exponentiation along with a bool indicating
         /// whether an overflow happened.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, overflowing_pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_pow)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_pow(self, mut exp: u32) -> (Self, bool) {

--- a/src/shared/saturating.rs
+++ b/src/shared/saturating.rs
@@ -2,7 +2,11 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         // Currently a no-op
     };
 }

--- a/src/shared/strict.rs
+++ b/src/shared/strict.rs
@@ -2,13 +2,17 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Strict integer addition. Computes `self + rhs`, panicking
         /// if overflow occurred.
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_add)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -24,7 +28,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_sub)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -40,7 +44,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_mul)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -56,7 +60,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_pow)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -72,7 +76,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_shl)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_shl)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -88,7 +92,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, strict_shr)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_shr)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]

--- a/src/shared/traits.rs
+++ b/src/shared/traits.rs
@@ -10,7 +10,7 @@ macro_rules! define {
     ($(
         type => $t:ty,
         impl => $trait:ident $(:: $ns:ident)*,
-        op => $op:ident,
+        op => $op:ident $(,)?
     )*) => ($(
         impl $trait $(::$ns)* <&$t> for $t {
             type Output = <Self as $trait $(::$ns)* >::Output;
@@ -28,7 +28,7 @@ macro_rules! define {
         impl => $trait:ident $(:: $ns1:ident)*,
         op => $op:ident,
         assign => $assign:ident $(:: $ns2:ident)*,
-        assign_op => $op_assign:ident,
+        assign_op => $op_assign:ident $(,)?
     )*) => ($(
         impl $trait $(::$ns1)* <&$t> for $t {
             type Output = <Self as $trait $(::$ns1)* >::Output;

--- a/src/shared/unbounded.rs
+++ b/src/shared/unbounded.rs
@@ -2,7 +2,10 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty $(,)?
+    ) => {
         /// Unbounded shift left. Computes `self << rhs`, without bounding the value
         /// of `rhs`.
         ///

--- a/src/shared/unchecked.rs
+++ b/src/shared/unchecked.rs
@@ -5,7 +5,11 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Unchecked integer addition. Computes `self + rhs`, assuming overflow
         /// cannot occur.
         ///
@@ -17,7 +21,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unchecked_add)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_add`]: Self::checked_add
@@ -44,7 +48,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unchecked_sub)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_sub`]: Self::checked_sub
@@ -71,7 +75,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::unchecked_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unchecked_mul)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`wrapping_mul`]: Self::wrapping_mul
@@ -96,7 +100,7 @@ macro_rules! define {
         /// or equal to the number of bits in `self`,
         /// i.e. when [`checked_shl`] would return `None`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_shl)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unchecked_shl)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_shl`]: Self::checked_shl
@@ -119,7 +123,7 @@ macro_rules! define {
         /// or equal to the number of bits in `self`,
         /// i.e. when [`checked_shr`] would return `None`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, unchecked_shr)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, unchecked_shr)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         ///
         /// [`checked_shr`]: Self::checked_shr

--- a/src/shared/wrapping.rs
+++ b/src/shared/wrapping.rs
@@ -2,11 +2,15 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (type => $t:ty,wide_type => $wide_t:ty) => {
+    (
+        type => $t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         /// Wrapping (modular) exponentiation. Computes `self.pow(exp)`,
         /// wrapping around at the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, wrapping_pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_pow)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_pow(self, mut exp: u32) -> Self {

--- a/src/types.rs
+++ b/src/types.rs
@@ -26,34 +26,82 @@
 // architecture can use 64-bit limbs, which is true of most modern systems.
 // This might not be true in which case we can address this at that time.
 
+#[rustfmt::skip]
+macro_rules! limb_doc {
+    () => {
+"
+This is guaranteed to have optimal performance for big integer
+to scalar operations, however, the type size may be 32 or
+64 bits depending on the architecture and pointer size.
+
+To guaranteed code is fully portable on 32 and 64-bit systems,
+use the fixed-width overloads. However, this might have suboptimal
+performance if the bits in the type used is larger than the limb.
+"
+    };
+}
+
+#[rustfmt::skip]
+macro_rules! wide_doc {
+    () => {
+"
+The performance of wide (double the bits of the limb) can be highly
+variable: for addition, multiplication, and subtraction it can be
+as fast as operations with limbs, however, the worst case performance
+is as slow as operations between big integers.
+
+For division, the performance is comparable to operations between two
+big integers. If iteratively processing data from 64-bit integers,
+you should benchmark first to see if, say, `((x as u128) * (y as u128)) * z`,
+where `z` is [`u256`][crate::u256], is faster than `(x * z) * y`.
+"
+    };
+}
+
 /// The unsigned type used as a native "limb".
+///
+#[doc = limb_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type ULimb = u64;
 
 /// The unsigned type used as a native "limb".
+///
+#[doc = limb_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type ULimb = u32;
 
 /// The same sized type of the limb as a signed integer.
+///
+#[doc = limb_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type ILimb = i64;
 
 /// The same sized type of the limb as a signed integer.
+///
+#[doc = limb_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type ILimb = i32;
 
 /// An unsigned type double the width of the limb.
+///
+#[doc = wide_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type UWide = u128;
 
 /// An unsigned type double the width of the limb.
+///
+#[doc = wide_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type UWide = u64;
 
 /// A signed type double the width of the limb.
+///
+#[doc = wide_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type IWide = i128;
 
 /// A signed type double the width of the limb.
+///
+#[doc = wide_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type IWide = i64;

--- a/src/types.rs
+++ b/src/types.rs
@@ -59,49 +59,41 @@ where `z` is [`u256`][crate::u256], is faster than `(x * z) * y`.
 }
 
 /// The unsigned type used as a native "limb".
-///
 #[doc = limb_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type ULimb = u64;
 
 /// The unsigned type used as a native "limb".
-///
 #[doc = limb_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type ULimb = u32;
 
 /// The same sized type of the limb as a signed integer.
-///
 #[doc = limb_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type ILimb = i64;
 
 /// The same sized type of the limb as a signed integer.
-///
 #[doc = limb_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type ILimb = i32;
 
 /// An unsigned type double the width of the limb.
-///
 #[doc = wide_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type UWide = u128;
 
 /// An unsigned type double the width of the limb.
-///
 #[doc = wide_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type UWide = u64;
 
 /// A signed type double the width of the limb.
-///
 #[doc = wide_doc!()]
 #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
 pub type IWide = i128;
 
 /// A signed type double the width of the limb.
-///
 #[doc = wide_doc!()]
 #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
 pub type IWide = i64;

--- a/src/uint/bitops.rs
+++ b/src/uint/bitops.rs
@@ -1,11 +1,19 @@
 //! Bitwise operations for our types.
 
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::bitops::define!(type => $s_t, wide_type => $wide_t);
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::bitops::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t
+        );
 
         #[inline(always)]
-        #[doc = $crate::shared::bitops::wrapping_shl_doc!(u128)]
+        #[doc = $crate::shared::bitops::wrapping_shl_doc!($see_t)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shl(self, rhs: u32) -> Self {
             let result = $crate::math::shift::left_uwide(self.to_ne_wide(), rhs % Self::BITS);
@@ -13,7 +21,7 @@ macro_rules! define {
         }
 
         #[inline(always)]
-        #[doc = $crate::shared::bitops::wrapping_shr_doc!(u128)]
+        #[doc = $crate::shared::bitops::wrapping_shr_doc!($see_t)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_shr(self, rhs: u32) -> Self {
             let result = $crate::math::shift::right_uwide(self.to_ne_wide(), rhs % Self::BITS);

--- a/src/uint/checked.rs
+++ b/src/uint/checked.rs
@@ -2,12 +2,20 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::checked::define!(type => $s_t, wide_type => $wide_t);
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::checked::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Checked addition with a signed integer. Computes `self + rhs`,
         /// returning `None` if overflow occurred.
-        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_add_signed)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_add_signed)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_signed(self, rhs: $s_t) -> Option<Self> {
@@ -23,7 +31,7 @@ macro_rules! define {
         /// 0`.
         ///
         /// Note that negating any positive integer will overflow.
-        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_neg)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_neg(self) -> Option<Self> {
@@ -42,7 +50,7 @@ macro_rules! define {
         /// This method might not be optimized owing to implementation details;
         /// `checked_ilog2` can produce results more efficiently for base 2, and
         /// `checked_ilog10` can produce results more efficiently for base 10.
-        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_ilog)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_ilog)]
         #[inline(always)]
         pub fn checked_ilog(self, base: Self) -> Option<u32> {
             let zero = Self::from_u8(0);
@@ -105,7 +113,7 @@ macro_rules! define {
         /// Calculates the smallest value greater than or equal to `self` that
         /// is a multiple of `rhs`. Returns `None` if `rhs` is zero or the
         /// operation would result in overflow.
-        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_next_multiple_of)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_next_multiple_of)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_next_multiple_of(self, rhs: Self) -> Option<Self> {
@@ -135,7 +143,7 @@ macro_rules! define {
         /// Returns the smallest power of two greater than or equal to `self`. If
         /// the next power of two is greater than the type's maximum value,
         /// `None` is returned, otherwise the power of two is wrapped in `Some`.
-        #[doc = $crate::shared::docs::primitive_doc!(u128, checked_next_power_of_two)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, checked_next_power_of_two)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_next_power_of_two(self) -> Option<Self> {

--- a/src/uint/constants.rs
+++ b/src/uint/constants.rs
@@ -4,25 +4,27 @@
 macro_rules! define {
     (
         bits => $bits:expr,
-        wide_type => $wide_t:ty $(,)?
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
     ) => {
         $crate::shared::constants::define!(
             bits => $bits,
             wide_type => $wide_t,
             low_type => $crate::ULimb,
             high_type => $crate::ULimb,
+            see_type => $see_t,
         );
 
         #[deprecated]
         #[inline(always)]
-        #[doc = $crate::shared::constants::min_value_doc!(u128)]
+        #[doc = $crate::shared::constants::min_value_doc!($see_t)]
         pub const fn min_value() -> Self {
             Self::from_ne_limbs([0; Self::LIMBS])
         }
 
         #[deprecated]
         #[inline(always)]
-        #[doc = $crate::shared::constants::max_value_doc!(u128)]
+        #[doc = $crate::shared::constants::max_value_doc!($see_t)]
         pub const fn max_value() -> Self {
             Self::from_ne_limbs([$crate::ULimb::MAX; Self::LIMBS])
         }

--- a/src/uint/extensions.rs
+++ b/src/uint/extensions.rs
@@ -1,7 +1,9 @@
 //! Custom integer extensions for ergonomics.
 
 macro_rules! define {
-    (high_type => $hi_t:ty) => {
+    (
+        high_type => $hi_t:ty $(,)?
+    ) => {
         $crate::shared::extensions::define!(high_type => $hi_t);
 
         /// Get the lower half of the integer, that is, the bits in `[0, BITS/2)`.

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -171,7 +171,48 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`u32`] to the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_u32(self, n: u32) -> Self {
+            self.wrapping_add_ulimb(n as $crate::ULimb)
+        }
+
+        /// Subtract [`u32`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_u32(self, n: u32) -> Self {
+            self.wrapping_sub_ulimb(n as $crate::ULimb)
+        }
+
+        /// Multiply our big integer by [`u32`], wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_u32(self, n: u32) -> Self {
+            self.wrapping_mul_ulimb(n as $crate::ULimb)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u32`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        ///
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_u32(self, n: u32) -> (Self, u32) {
+            let (quo, rem) = self.wrapping_div_rem_ulimb(n as $crate::ULimb);
+            (quo, rem as u32)
+        }
 
         // U64
 
@@ -295,7 +336,35 @@ macro_rules! define {
 
         // U32
 
-        // TODO: Add
+        /// Add [`u32`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_u32(self, n: u32) -> (Self, bool) {
+            self.overflowing_add_ulimb(n as $crate::ULimb)
+        }
+
+        /// Subtract [`u32`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_u32(self, n: u32) -> (Self, bool) {
+            self.overflowing_sub_ulimb(n as $crate::ULimb)
+        }
+
+        /// Multiply our big integer by [`u32`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_u32(self, n: u32) -> (Self, bool) {
+            self.overflowing_mul_ulimb(n as $crate::ULimb)
+        }
 
         // U64
 

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -122,9 +122,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_uwide(self, n: $crate::UWide) -> Self {
-            todo!();
-            //let limbs = $crate::math::sub::wrapping_wide(&self.to_ne_limbs(), n);
-            //Self::from_ne_limbs(limbs)
+            let limbs = $crate::math::sub::wrapping_wide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
         }
 
         /// Multiply our big integer by [`UWide`][crate::UWide], wrapping on
@@ -260,9 +259,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_uwide(self, n: $crate::UWide) -> (Self, bool) {
-            todo!();
-            //let (limbs, overflowed) = $crate::math::sub::overflowing_wide(&self.to_ne_limbs(), n);
-            //(Self::from_ne_limbs(limbs), overflowed)
+            let (limbs, overflowed) = $crate::math::sub::overflowing_wide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
         }
 
         /// Multiply our big integer by [`UWide`][crate::UWide], returning the value

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -224,11 +224,142 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`u64`] to the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_u64(self, n: u64) -> Self {
+            let limbs = $crate::math::add::wrapping_scalar_u64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Subtract [`u64`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_u64(self, n: u64) -> Self {
+            let limbs = $crate::math::sub::wrapping_scalar_u64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Multiply our big integer by [`u64`], wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_u64(self, n: u64) -> Self {
+            let limbs = $crate::math::mul::wrapping_scalar_u64(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u64`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        ///
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_u64(self, n: u64) -> (Self, u64) {
+            const BITS: u32 = $crate::ULimb::BITS;
+            assert!(BITS == 32 || BITS == 64);
+            if BITS == 32 {
+                let (quo, rem) = self.wrapping_div_rem_uwide(n as $crate::UWide);
+                (quo, rem as u64)
+            } else {
+                let (quo, rem) = self.wrapping_div_rem_ulimb(n as $crate::ULimb);
+                (quo, rem as u64)
+            }
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`u128`] to the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_u128(self, n: u128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_add_uwide(n as $crate::UWide)
+            } else {
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb(n);
+                let limbs = $crate::math::add::wrapping_mn(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Subtract [`u128`] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_u128(self, n: u128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_sub_uwide(n as $crate::UWide)
+            } else {
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb(n);
+                let limbs = $crate::math::sub::wrapping_mn(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Multiply our big integer by [`u128`], wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_u128(self, n: u128) -> Self {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.wrapping_mul_uwide(n as $crate::UWide)
+            } else {
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb(n);
+                let limbs = $crate::math::mul::wrapping_unsigned(&lhs, &rhs);
+                Self::from_ne_limbs(limbs)
+            }
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`u128`], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(division)]
+        ///
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_u128(self, n: u128) -> (Self, u128) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                let (quo, rem) = self.wrapping_div_rem_uwide(n as $crate::UWide);
+                (quo, rem as u128)
+            } else {
+                let (div, rem) = $crate::math::div::from_u128(&self.to_le_limbs(), n);
+                let div = Self::from_le_limbs(div);
+                (div, rem)
+            }
+        }
     };
 
     (@overflowing) => {
@@ -380,11 +511,100 @@ macro_rules! define {
 
         // U64
 
-        // TODO: Add
+        /// Add [`u64`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_u64(self, n: u64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::add::overflowing_scalar_u64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Subtract [`u64`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_u64(self, n: u64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::sub::overflowing_scalar_u64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Multiply our big integer by [`u64`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_u64(self, n: u64) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::mul::overflowing_scalar_u64(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
 
         // U128
 
-        // TODO: Add
+        /// Add [`u128`] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_u128(self, n: u128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_add_uwide(n as $crate::UWide)
+            } else {
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb(n);
+                let (limbs, overflowed) = $crate::math::add::overflowing_mn(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Subtract [`u128`] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_u128(self, n: u128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_sub_uwide(n as $crate::UWide)
+            } else {
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb(n);
+                let (limbs, overflowed) = $crate::math::sub::overflowing_mn(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
+
+        /// Multiply our big integer by [`u128`], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_u128(self, n: u128) -> (Self, bool) {
+            const BITS: u32 = $crate::UWide::BITS;
+            assert!(BITS == 64 || BITS == 128);
+            if BITS == 128 {
+                // this contains optimizations: keep this branch
+                self.overflowing_mul_uwide(n as $crate::UWide)
+            } else {
+                let lhs = self.to_ne_limbs();
+                let rhs = $crate::util::u128_to_limb(n);
+                let (limbs, overflowed) = $crate::math::mul::overflowing_unsigned(&lhs, &rhs);
+                (Self::from_ne_limbs(limbs), overflowed)
+            }
+        }
     };
 
     (@checked) => {

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -5,6 +5,10 @@ macro_rules! define {
         $crate::shared::limb::define!();
     };
 
+    (fixed) => {
+        $crate::shared::limb::define!(fixed);
+    };
+
     (@wrapping) => {
         $crate::shared::limb::define!(@wrapping);
 
@@ -168,6 +172,10 @@ macro_rules! define {
             let div = Self::from_le_limbs(div);
             (div, rem)
         }
+    };
+
+    (@wrapping-fixed) => {
+        $crate::shared::limb::define!(@wrapping-fixed);
 
         // U32
 
@@ -333,6 +341,10 @@ macro_rules! define {
             let (limbs, overflowed) = $crate::math::mul::overflowing_wide(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
         }
+    };
+
+    (@overflowing-fixed) => {
+        $crate::shared::limb::define!(@overflowing-fixed);
 
         // U32
 
@@ -379,11 +391,24 @@ macro_rules! define {
         $crate::shared::limb::define!(@checked);
     };
 
+    (@checked-fixed) => {
+        $crate::shared::limb::define!(@checked-fixed);
+    };
+
     (@all) => {
         $crate::uint::limb::define!();
         $crate::uint::limb::define!(@wrapping);
         $crate::uint::limb::define!(@overflowing);
         $crate::uint::limb::define!(@checked);
+
+        #[cfg(feature = "stdint")]
+        $crate::uint::limb::define!(fixed);
+        #[cfg(feature = "stdint")]
+        $crate::uint::limb::define!(@wrapping-fixed);
+        #[cfg(feature = "stdint")]
+        $crate::uint::limb::define!(@overflowing-fixed);
+        #[cfg(feature = "stdint")]
+        $crate::uint::limb::define!(@checked-fixed);
     };
 }
 

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -111,9 +111,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_uwide(self, n: $crate::UWide) -> Self {
-            todo!();
-            //let limbs = $crate::math::add::wrapping_wide(&self.to_ne_limbs(), n);
-            //Self::from_ne_limbs(limbs)
+            let limbs = $crate::math::add::wrapping_wide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
         }
 
         /// Subtract [`UWide`][crate::UWide] from the big integer, wrapping on
@@ -250,9 +249,8 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_uwide(self, n: $crate::UWide) -> (Self, bool) {
-            todo!();
-            //let (limbs, overflowed) = $crate::math::add::overflowing_wide(&self.to_ne_limbs(), n);
-            //(Self::from_ne_limbs(limbs), overflowed)
+            let (limbs, overflowed) = $crate::math::add::overflowing_wide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
         }
 
         /// Subtract [`UWide`][crate::UWide] from the big integer, returning the value

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -8,7 +8,9 @@ macro_rules! define {
     (@wrapping) => {
         $crate::shared::limb::define!(@wrapping);
 
-        /// Add an unsigned limb to the big integer, wrapping on
+        // LIMB
+
+        /// Add [`ULimb`][crate::ULimb] to the big integer, wrapping on
         /// overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
@@ -19,7 +21,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Subtract an unsigned limb from the big integer, wrapping on
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer, wrapping on
         /// overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
@@ -30,7 +32,7 @@ macro_rules! define {
             Self::from_ne_limbs(limbs)
         }
 
-        /// Multiply our big integer by an unsigned limb, wrapping on
+        /// Multiply our big integer by [`ULimb`][crate::ULimb], wrapping on
         /// overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
@@ -87,7 +89,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by an unsigned limb, wrapping on overflow.
+        /// by [`ULimb`][crate::ULimb], wrapping on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         ///
@@ -95,17 +97,101 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_ulimb(self, n: $crate::ULimb) -> (Self, $crate::ULimb) {
-            let x = self.to_le_limbs();
-            let (div, rem) = $crate::math::div::limb(&x, n);
+            let (div, rem) = $crate::math::div::limb(&self.to_le_limbs(), n);
             let div = Self::from_le_limbs(div);
             (div, rem)
         }
+
+        // WIDE
+
+        /// Add [`UWide`][crate::UWide] to the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_add_uwide(self, n: $crate::UWide) -> Self {
+            todo!();
+            //let limbs = $crate::math::add::wrapping_wide(&self.to_ne_limbs(), n);
+            //Self::from_ne_limbs(limbs)
+        }
+
+        /// Subtract [`UWide`][crate::UWide] from the big integer, wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_sub_uwide(self, n: $crate::UWide) -> Self {
+            todo!();
+            //let limbs = $crate::math::sub::wrapping_wide(&self.to_ne_limbs(), n);
+            //Self::from_ne_limbs(limbs)
+        }
+
+        /// Multiply our big integer by [`UWide`][crate::UWide], wrapping on
+        /// overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        ///
+        /// Many different algorithms were attempted, with a soft [`mulx`] approach
+        /// (1), a flat, fixed-width long multiplication (2), and a
+        /// short-circuiting long multiplication (3). Algorithm (3) had the best
+        /// performance for 128-bit multiplication, however, algorithm (1) was
+        /// better for smaller type sizes.
+        ///
+        /// This also optimized much better when multiplying by a single or a
+        /// half-sized item: rather than using 4 limbs, if we're multiplying
+        /// `(u128, u128) * u128`, we can use 2 limbs for the right operand, and
+        /// for `(u128, u128) * u64`, only 1 limb.
+        ///
+        /// Using algorithm (3), the addition of `(u128, u128) + (u128, u128)` is in
+        /// the worst case 10 `mul` and 13 `add` instructions, while `(u128,
+        /// u128) + u64` is always 4 `mul` and 3 `add` instructions without any
+        /// branching. This is extremely efficient.
+        ///
+        /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn wrapping_mul_uwide(self, n: $crate::UWide) -> Self {
+            let limbs = $crate::math::mul::wrapping_wide(&self.to_ne_limbs(), n);
+            Self::from_ne_limbs(limbs)
+        }
+
+        /// Get the quotient and remainder of our big integer divided
+        /// by [`UWide`][crate::UWide], wrapping on overflow.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(division)]
+        ///
+        #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub fn wrapping_div_rem_uwide(self, n: $crate::UWide) -> (Self, $crate::UWide) {
+            let x = self.to_le_limbs();
+            todo!();
+            //let (div, rem) = $crate::math::div::wide(&x, n);
+            //let div = Self::from_le_limbs(div);
+            //(div, rem)
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@overflowing) => {
         $crate::shared::limb::define!(@overflowing);
 
-        /// Add an unsigned limb to the big integer, returning the value
+        // LIMB
+
+        /// Add [`ULimb`][crate::ULimb] to the big integer, returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
@@ -116,7 +202,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Subtract an unsigned limb from the big integer, returning the value
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer, returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
@@ -127,7 +213,7 @@ macro_rules! define {
             (Self::from_ne_limbs(limbs), overflowed)
         }
 
-        /// Multiply our big integer by an unsigned limb, returning the value
+        /// Multiply our big integer by [`ULimb`][crate::ULimb], returning the value
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
@@ -156,6 +242,74 @@ macro_rules! define {
             let (limbs, overflowed) = $crate::math::mul::overflowing_limb(&self.to_ne_limbs(), n);
             (Self::from_ne_limbs(limbs), overflowed)
         }
+
+        // WIDE
+
+        /// Add [`UWide`][crate::UWide] to the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_add_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            todo!();
+            //let (limbs, overflowed) = $crate::math::add::overflowing_wide(&self.to_ne_limbs(), n);
+            //(Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Subtract [`UWide`][crate::UWide] from the big integer, returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_sub_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            todo!();
+            //let (limbs, overflowed) = $crate::math::sub::overflowing_wide(&self.to_ne_limbs(), n);
+            //(Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        /// Multiply our big integer by [`UWide`][crate::UWide], returning the value
+        /// and if overflow occurred.
+        ///
+        #[doc = $crate::shared::docs::wide_doc!(multiplication)]
+        ///
+        /// Many different algorithms were attempted, with a soft [`mulx`] approach
+        /// (1), a flat, fixed-width long multiplication (2), and a
+        /// short-circuiting long multiplication (3). Algorithm (3) had the best
+        /// performance for 128-bit multiplication, however, algorithm (1) was
+        /// better for smaller type sizes.
+        ///
+        /// This also optimized much better when multiplying by a single or a
+        /// half-sized item: rather than using 4 limbs, if we're multiplying
+        /// `(u128, u128) * u128`, we can use 2 limbs for the right operand, and
+        /// for `(u128, u128) * u64`, only 1 limb.
+        ///
+        /// # Assembly
+        ///
+        /// The analysis here is practically identical to that of
+        /// [`wrapping_mul_uwide`].
+        ///
+        /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
+        /// [`wrapping_mul_uwide`]: Self::wrapping_mul_uwide
+        #[inline(always)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn overflowing_mul_uwide(self, n: $crate::UWide) -> (Self, bool) {
+            let (limbs, overflowed) = $crate::math::mul::overflowing_wide(&self.to_ne_limbs(), n);
+            (Self::from_ne_limbs(limbs), overflowed)
+        }
+
+        // U32
+
+        // TODO: Add
+
+        // U64
+
+        // TODO: Add
+
+        // U128
+
+        // TODO: Add
     };
 
     (@checked) => {

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -166,11 +166,9 @@ macro_rules! define {
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_uwide(self, n: $crate::UWide) -> (Self, $crate::UWide) {
-            let x = self.to_le_limbs();
-            todo!();
-            //let (div, rem) = $crate::math::div::wide(&x, n);
-            //let div = Self::from_le_limbs(div);
-            //(div, rem)
+            let (div, rem) = $crate::math::div::wide(&self.to_le_limbs(), n);
+            let div = Self::from_le_limbs(div);
+            (div, rem)
         }
 
         // U32

--- a/src/uint/mod.rs
+++ b/src/uint/mod.rs
@@ -35,8 +35,6 @@ pub(crate) mod wrapping;
 /// crate::uint::define!(
 ///     name => u256,
 ///     signed_t => crate::i256,
-///     signed_wide_t => i128,
-///     unsigned_wide_t => u128,
 ///     bits => 256,
 /// );
 /// ```
@@ -44,8 +42,6 @@ macro_rules! define {
     (
         name => $name:ident,
         signed_t => $s_t:ty,
-        signed_wide_t => $wide_s_t:ty,
-        unsigned_wide_t => $wide_u_t:ty,
         bits => $bits:expr $(,)?
     ) => {
         $crate::shared::int_struct_define!(
@@ -57,30 +53,75 @@ macro_rules! define {
         impl $name {
             $crate::uint::constants::define!(
                 bits => $bits,
-                wide_type => $wide_u_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
             );
-            $crate::uint::bitops::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::shared::endian::define!(type => $s_t, wide_type => $wide_s_t);
+            $crate::uint::bitops::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::shared::endian::define!(
+                type => $s_t,
+                wide_type => $crate::IWide,
+                see_type => u64,
+            );
             $crate::shared::ord::define!(
-                low_type => $wide_u_t,
-                high_type => $wide_u_t,
+                low_type => $crate::UWide,
+                high_type => $crate::UWide,
             );
             $crate::uint::casts::define!(
                 signed_type => $s_t,
                 bits => $bits,
-                wide_type => $wide_u_t,
+                wide_type => $crate::UWide,
                 kind => unsigned,
             );
-            $crate::uint::extensions::define!(high_type => $crate::ULimb);
-            $crate::uint::ops::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::shared::bigint::define!(wide_type => $wide_u_t);
-            $crate::uint::wrapping::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::uint::overflowing::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::uint::saturating::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::uint::checked::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::uint::strict::define!(signed_type => $s_t, wide_type => $wide_u_t);
-            $crate::shared::unchecked::define!(type => $s_t, wide_type => $wide_u_t);
-            $crate::shared::unbounded::define!(type => $s_t, wide_type => $wide_u_t);
+            $crate::uint::extensions::define!(
+                high_type => $crate::ULimb,
+            );
+            $crate::uint::ops::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::shared::bigint::define!(
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::uint::wrapping::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::uint::overflowing::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::uint::saturating::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::uint::checked::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::uint::strict::define!(
+                signed_type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::shared::unchecked::define!(
+                type => $s_t,
+                wide_type => $crate::UWide,
+                see_type => u64,
+            );
+            $crate::shared::unbounded::define!(
+                type => $s_t,
+                wide_type => $crate::UWide,
+            );
             $crate::uint::limb::define!(@all);
 
             $crate::parse::define!(false);

--- a/src/uint/ops.rs
+++ b/src/uint/ops.rs
@@ -2,7 +2,11 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
         #[inline(always)]
         const fn is_div_overflow(self, rhs: Self) -> bool {
             _ = rhs;
@@ -15,7 +19,11 @@ macro_rules! define {
             rhs.eq_const(Self::from_u8(0))
         }
 
-        $crate::shared::ops::define!(type => $s_t, wide_type => u128);
+        $crate::shared::ops::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Performs Euclidean division.
         ///
@@ -25,7 +33,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, div_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_euclid(self, rhs: Self) -> Self {
@@ -47,7 +55,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, rem_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_euclid(self, rhs: Self) -> Self {
@@ -68,7 +76,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, div_floor)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, div_floor)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_floor(self, rhs: Self) -> Self {
@@ -80,7 +88,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, div_ceil)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, div_ceil)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_ceil(self, rhs: Self) -> Self {
@@ -104,7 +112,7 @@ macro_rules! define {
         ///
         /// This function will panic if `self` is zero, or if `base` is less than 2.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, ilog)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, ilog)]
         #[inline(always)]
         pub fn ilog(self, base: Self) -> u32 {
             if let Some(log) = self.checked_ilog(base) {
@@ -118,7 +126,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!(self)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, ilog2)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, ilog2)]
         #[inline(always)]
         pub const fn ilog2(self) -> u32 {
             if let Some(log) = self.checked_ilog2() {
@@ -152,7 +160,7 @@ macro_rules! define {
 
         /// Computes the absolute difference between `self` and `other`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, abs_diff)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, abs_diff)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn abs_diff(self, other: Self) -> Self {

--- a/src/uint/overflowing.rs
+++ b/src/uint/overflowing.rs
@@ -3,8 +3,16 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::overflowing::define!(type => $s_t, wide_type => $wide_t);
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::overflowing::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Calculates `self` + `rhs`.
         ///
@@ -12,7 +20,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_add)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add(self, rhs: Self) -> (Self, bool) {
@@ -28,7 +36,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_add_signed)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_add_signed)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_signed(self, rhs: $s_t) -> (Self, bool) {
@@ -43,7 +51,7 @@ macro_rules! define {
         /// whether an arithmetic overflow would occur. If an overflow would
         /// have occurred then the wrapped value is returned.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_sub)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub(self, rhs: Self) -> (Self, bool) {
@@ -86,7 +94,7 @@ macro_rules! define {
         ///
         /// The analysis here is practically identical to that of [`wrapping_mul`].
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_mul)]
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         /// [`wrapping_mul`]: Self::wrapping_mul
@@ -108,7 +116,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_div)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div(self, rhs: Self) -> (Self, bool) {
@@ -127,7 +135,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_div_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_euclid(self, rhs: Self) -> (Self, bool) {
@@ -143,7 +151,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_rem)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem(self, rhs: Self) -> (Self, bool) {
@@ -163,7 +171,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, overflowing_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, overflowing_rem_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_euclid(self, rhs: Self) -> (Self, bool) {

--- a/src/uint/saturating.rs
+++ b/src/uint/saturating.rs
@@ -2,13 +2,21 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::saturating::define!(type => $s_t, wide_type => $wide_t);
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::saturating::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Saturating integer addition. Computes `self + rhs`, saturating at
         /// the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_add)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add(self, rhs: Self) -> Self {
@@ -21,7 +29,7 @@ macro_rules! define {
         /// Saturating addition with a signed integer. Computes `self + rhs`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_add_signed)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_add_signed)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_add_signed(self, rhs: $s_t) -> Self {
@@ -39,7 +47,7 @@ macro_rules! define {
         /// Saturating integer subtraction. Computes `self - rhs`, saturating
         /// at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_sub)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_sub(self, rhs: Self) -> Self {
@@ -52,7 +60,7 @@ macro_rules! define {
         /// Saturating integer multiplication. Computes `self * rhs`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_mul)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_mul(self, rhs: Self) -> Self {
@@ -67,7 +75,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_div)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn saturating_div(self, rhs: Self) -> Self {
@@ -78,7 +86,7 @@ macro_rules! define {
         /// Saturating integer exponentiation. Computes `self.pow(exp)`,
         /// saturating at the numeric bounds instead of overflowing.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, saturating_pow)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, saturating_pow)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn saturating_pow(self, exp: u32) -> Self {

--- a/src/uint/strict.rs
+++ b/src/uint/strict.rs
@@ -2,15 +2,23 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::strict::define!(type => $s_t, wide_type => $wide_t);
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::strict::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Strict addition with a signed integer. Computes `self + rhs`,
         /// panicking if overflow occurred.
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_add_signed)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_add_signed)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -29,7 +37,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_div)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -49,7 +57,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_rem)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -70,7 +78,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_div_euclid)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -92,7 +100,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(div-zero)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_rem_euclid)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
@@ -110,7 +118,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::strict_doc!(panics)]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, strict_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, strict_neg)]
         #[doc = $crate::shared::docs::nightly_doc!()]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]

--- a/src/uint/traits.rs
+++ b/src/uint/traits.rs
@@ -1,7 +1,10 @@
 //! Helpers and logic for working with traits.
 
 macro_rules! define {
-    (type => $t:ident,signed_type => $s_t:ty) => {
+    (
+        type => $t:ident,
+        signed_type => $s_t:ty $(,)?
+    ) => {
         $crate::shared::traits::define!(impl => $t);
         $crate::shared::shift::define! { big => $t, impl => $s_t }
         $crate::shared::shift::define! { reference => $t, impl => $s_t }

--- a/src/uint/wrapping.rs
+++ b/src/uint/wrapping.rs
@@ -2,13 +2,21 @@
 
 #[rustfmt::skip]
 macro_rules! define {
-    (signed_type => $s_t:ty, wide_type => $wide_t:ty) => {
-        $crate::shared::wrapping::define!(type => $s_t, wide_type => $wide_t);
+    (
+        signed_type => $s_t:ty,
+        wide_type => $wide_t:ty,
+        see_type => $see_t:ty $(,)?
+    ) => {
+        $crate::shared::wrapping::define!(
+            type => $s_t,
+            wide_type => $wide_t,
+            see_type => $see_t,
+        );
 
         /// Wrapping (modular) addition. Computes `self + rhs`,
         /// wrapping around at the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_add)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_add)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add(self, rhs: Self) -> Self {
@@ -19,7 +27,7 @@ macro_rules! define {
         /// Wrapping (modular) addition with a signed integer. Computes
         /// `self + rhs`, wrapping around at the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_add_signed)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_add_signed)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_signed(self, rhs: $s_t) -> Self {
@@ -29,11 +37,13 @@ macro_rules! define {
         /// Wrapping (modular) subtraction. Computes `self - rhs`,
         /// wrapping around at the boundary of the type.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_sub)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_sub)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub(self, rhs: Self) -> Self {
-            let result = $crate::math::sub::wrapping_unsigned(&self.to_ne_limbs(), &rhs.to_ne_limbs());
+            let lhs = self.to_ne_limbs();
+            let rhs = rhs.to_ne_limbs();
+            let result = $crate::math::sub::wrapping_unsigned(&lhs, &rhs);
             Self::from_ne_limbs(result)
         }
 
@@ -65,7 +75,7 @@ macro_rules! define {
         /// because of branching in nearly every case, it has better performance
         /// and optimizes nicely for small multiplications.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_mul)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_mul)]
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         #[inline(always)]
@@ -235,7 +245,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_div)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_div)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div(self, rhs: Self) -> Self {
@@ -252,7 +262,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_div_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_div_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_euclid(self, rhs: Self) -> Self {
@@ -268,7 +278,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_rem)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_rem)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem(self, rhs: Self) -> Self {
@@ -286,7 +296,7 @@ macro_rules! define {
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!()]
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_rem_euclid)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_rem_euclid)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_euclid(self, rhs: Self) -> Self {
@@ -303,7 +313,7 @@ macro_rules! define {
         /// Any larger values are equivalent to `MAX + 1 - (val - MAX - 1)` where
         /// `MAX` is the corresponding signed type's maximum.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_neg)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_neg)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_neg(self) -> Self {
@@ -314,7 +324,7 @@ macro_rules! define {
         /// the next power of two is greater than the type's maximum value,
         /// the return value is wrapped to `0`.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, wrapping_next_power_of_two)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, wrapping_next_power_of_two)]
         #[inline]
         pub const fn wrapping_next_power_of_two(self) -> Self {
             self.one_less_than_next_power_of_two().wrapping_add(Self::from_u8(1))

--- a/src/util.rs
+++ b/src/util.rs
@@ -44,6 +44,8 @@ macro_rules! swap_array {
 }
 
 /// Conditionally implement a function correctly based on the types.
+///
+/// Note this also supports wide API methods, with the same overloads.
 #[doc(hidden)]
 #[macro_export]
 macro_rules! limb_function {

--- a/src/util.rs
+++ b/src/util.rs
@@ -65,4 +65,101 @@ macro_rules! limb_function {
     ($name:ident, $bit64:ident, $bit32:ident, $t:ty, ret => $ret:ty) => {
         limb_function!($name, $bit64, $bit32, $t, $t, ret => $ret);
     };
+
+    (mn $name:ident, $bit64:ident, $bit32:ident, $t1:ty, $t2:ty, ret => $ret:ty) => {
+        #[inline(always)]
+        pub const fn $name<const M: usize, const N: usize>(x: $t1, y: $t2) -> $ret {
+            #[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
+            let result = $bit64(x, y);
+
+            #[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
+            let result = $bit32(x, y);
+
+            result
+        }
+    };
+
+    (mn $name:ident, $bit64:ident, $bit32:ident, $t:ty, ret => $ret:ty) => {
+        limb_function!(mn $name, $bit64, $bit32, $t, $t, ret => $ret);
+    };
+}
+
+/// No-op, this is meant for 32-bit ISAs.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
+pub(crate) const fn u128_to_limb(value: u128) -> [u64; 2] {
+    _ = value;
+    unimplemented!();
+}
+
+/// Simple, safe transmute to ensure we transmute the value to native order.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[allow(clippy::assertions_on_constants)]
+#[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
+pub(crate) const fn u128_to_limb(value: u128) -> [u32; 4] {
+    assert!(crate::ULimb::BITS == 32);
+
+    let bytes = value.to_ne_bytes();
+    // SAFETY: Safe since plain old data
+    unsafe { core::mem::transmute::<[u8; 16], [u32; 4]>(bytes) }
+}
+
+/// No-op, this is meant for 32-bit ISAs.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
+pub(crate) const fn u128_to_limb_n<const N: usize>(value: u128) -> [u64; N] {
+    _ = value;
+    unimplemented!();
+}
+
+/// Simple, safe transmute to ensure we transmute the value to native order
+/// at a fixed with.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[allow(clippy::assertions_on_constants)]
+#[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
+pub(crate) const fn u128_to_limb_n<const N: usize>(value: u128) -> [u32; N] {
+    assert!(crate::ULimb::BITS == 32);
+    assert!(N > 4);
+
+    let mut result = [0; N];
+    ne_index!(result[0] = value as u32);
+    ne_index!(result[1] = (value >> 96) as u32);
+    ne_index!(result[2] = (value >> 64) as u32);
+    ne_index!(result[3] = (value >> 32) as u32);
+
+    result
+}
+
+/// No-op, this is meant for 32-bit ISAs.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[cfg(all(not(feature = "limb32"), target_pointer_width = "64"))]
+pub(crate) const fn i128_to_limb_n<const N: usize>(value: i128) -> [u64; N] {
+    _ = value;
+    unimplemented!();
+}
+
+/// Simple, safe transmute to ensure we transmute the value to native order
+/// at a fixed with.
+#[inline(always)]
+#[cfg(feature = "stdint")]
+#[allow(clippy::assertions_on_constants)]
+#[cfg(any(feature = "limb32", not(target_pointer_width = "64")))]
+pub(crate) const fn i128_to_limb_n<const N: usize>(value: i128) -> [u32; N] {
+    assert!(crate::ULimb::BITS == 32);
+    assert!(N > 4);
+
+    let sign_bit = u32::MIN.wrapping_sub(value.is_negative() as u32);
+    let value = value as u128;
+    let mut result = [sign_bit; N];
+    ne_index!(result[0] = value as u32);
+    ne_index!(result[1] = (value >> 96) as u32);
+    ne_index!(result[2] = (value >> 64) as u32);
+    ne_index!(result[3] = (value >> 32) as u32);
+
+    result
 }


### PR DESCRIPTION
This also adds (a feature-gated, default to on) API for methods multiplying by scalars guaranteed to be of a certain width, since 64-bit multiplies may be more expensive on 32-bit architectures, so the limb size is dependent on the architecture. The fixed-width scalar APIs, at the potential cost of performance, guarantee complete API stability across all platforms.

Closes #61.