### PR TITLE
docs: show required features and remove unrelated notes

### DIFF
--- a/src/int/casts.rs
+++ b/src/int/casts.rs
@@ -5,7 +5,7 @@ macro_rules! define {
     (
         unsigned_type => $u_t:ty,
         bits => $bits:expr,
-        wide_type => $wide_t:ty,
+        see_type => $see_t:ty,
         kind => $kind:ident $(,)?
     ) => {
         $crate::shared::casts::define!(
@@ -21,7 +21,7 @@ macro_rules! define {
         /// This produces the same result as an `as` cast, but ensures that the
         /// bit-width remains the same.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!($wide_t, cast_unsigned)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, cast_unsigned)]
         #[inline(always)]
         pub const fn cast_unsigned(self) -> $u_t {
             self.as_unsigned()

--- a/src/int/limb.rs
+++ b/src/int/limb.rs
@@ -182,7 +182,8 @@ macro_rules! define {
 
         /// Add [`i32`] to the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_i32(self, n: i32) -> Self {
@@ -198,7 +199,8 @@ macro_rules! define {
 
         /// Subtract [`i32`] from the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_i32(self, n: i32) -> Self {
@@ -214,7 +216,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`i32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_i32(self, n: i32) -> Self {
@@ -231,7 +234,8 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`i32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_i32(self, n: i32) -> (Self, i32) {
@@ -247,7 +251,8 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by [`i32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_i32(self, n: i32) -> Self {
@@ -256,7 +261,8 @@ macro_rules! define {
 
         /// Get the remainder of our big integer divided by [`i32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_i32(self, n: i32) -> i32 {
@@ -267,7 +273,8 @@ macro_rules! define {
 
         /// Add [`i64`] to the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_i64(self, n: i64) -> Self {
@@ -283,7 +290,8 @@ macro_rules! define {
 
         /// Subtract [`i64`] from the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_i64(self, n: i64) -> Self {
@@ -299,7 +307,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`i64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_i64(self, n: i64) -> Self {
@@ -316,7 +325,8 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`i64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_i64(self, n: i64) -> (Self, i64) {
@@ -332,7 +342,8 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by [`i64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_i64(self, n: i64) -> Self {
@@ -341,7 +352,8 @@ macro_rules! define {
 
         /// Get the remainder of our big integer divided by [`i64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_i64(self, n: i64) -> i64 {
@@ -352,7 +364,8 @@ macro_rules! define {
 
         /// Add [`i128`] to the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_i128(self, n: i128) -> Self {
@@ -368,7 +381,8 @@ macro_rules! define {
 
         /// Subtract [`i128`] from the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_i128(self, n: i128) -> Self {
@@ -384,7 +398,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`i128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_i128(self, n: i128) -> Self {
@@ -401,7 +416,8 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`i128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_i128(self, n: i128) -> (Self, i128) {
@@ -417,7 +433,8 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by [`i128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_i128(self, n: i128) -> Self {
@@ -426,7 +443,8 @@ macro_rules! define {
 
         /// Get the remainder of our big integer divided by [`i128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_i128(self, n: i128) -> i128 {
@@ -721,7 +739,8 @@ macro_rules! define {
 
         /// Add [`u32`] to the big integer, wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_u32(self, n: u32) -> Self {
@@ -730,7 +749,8 @@ macro_rules! define {
 
         /// Add [`i32`] to the big integer, wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_i32(self, n: i32) -> Self {
@@ -740,7 +760,8 @@ macro_rules! define {
         /// Subtract [`u32`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_u32(self, n: u32) -> Self {
@@ -750,7 +771,8 @@ macro_rules! define {
         /// Subtract [`i32`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_i32(self, n: i32) -> Self {
@@ -759,7 +781,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`u32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_u32(self, n: u32) -> Self {
@@ -768,7 +791,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`i32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_i32(self, n: i32) -> Self {
@@ -778,10 +802,11 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         /// This always wraps, which can never happen in practice. This
         /// has to use the floor division since we can never have a non-
         /// negative rem.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_u32(self, n: u32) -> (Self, u32) {
@@ -792,8 +817,9 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`i32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         /// This always wraps, which can never happen in practice.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_i32(self, n: i32) -> (Self, i32) {
@@ -804,7 +830,8 @@ macro_rules! define {
         /// Get the quotient of our big integer divided
         /// by [`i32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_i32(self, n: i32) -> Self {
@@ -814,7 +841,8 @@ macro_rules! define {
         /// Get the remainder of our big integer divided
         /// by [`i32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_i32(self, n: i32) -> i32 {
@@ -825,7 +853,8 @@ macro_rules! define {
 
         /// Add [`u64`] to the big integer, wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_u64(self, n: u64) -> Self {
@@ -835,7 +864,8 @@ macro_rules! define {
 
         /// Add [`i64`] to the big integer, wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_i64(self, n: i64) -> Self {
@@ -846,7 +876,8 @@ macro_rules! define {
         /// Subtract [`u64`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_u64(self, n: u64) -> Self {
@@ -857,7 +888,8 @@ macro_rules! define {
         /// Subtract [`i64`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_i64(self, n: i64) -> Self {
@@ -867,7 +899,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`u64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_u64(self, n: u64) -> Self {
@@ -877,7 +910,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`i64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_i64(self, n: i64) -> Self {
@@ -888,10 +922,11 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         /// This always wraps, which can never happen in practice. This
         /// has to use the floor division since we can never have a non-
         /// negative rem.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_u64(self, n: u64) -> (Self, u64) {
@@ -909,8 +944,9 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`i64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         /// This always wraps, which can never happen in practice.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_i64(self, n: i64) -> (Self, i64) {
@@ -928,7 +964,8 @@ macro_rules! define {
         /// Get the quotient of our big integer divided
         /// by [`i64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_i64(self, n: i64) -> Self {
@@ -938,7 +975,8 @@ macro_rules! define {
         /// Get the remainder of our big integer divided
         /// by [`i64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_i64(self, n: i64) -> i64 {
@@ -949,7 +987,8 @@ macro_rules! define {
 
         /// Add [`u128`] to the big integer, wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_u128(self, n: u128) -> Self {
@@ -969,7 +1008,8 @@ macro_rules! define {
 
         /// Add [`i128`] to the big integer, wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_i128(self, n: i128) -> Self {
@@ -990,7 +1030,8 @@ macro_rules! define {
         /// Subtract [`u128`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_u128(self, n: u128) -> Self {
@@ -1011,7 +1052,8 @@ macro_rules! define {
         /// Subtract [`i128`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_i128(self, n: i128) -> Self {
@@ -1031,7 +1073,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`u128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_u128(self, n: u128) -> Self {
@@ -1051,7 +1094,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`i128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_i128(self, n: i128) -> Self {
@@ -1072,10 +1116,11 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         /// This always wraps, which can never happen in practice. This
         /// has to use the floor division since we can never have a non-
         /// negative rem.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_u128(self, n: u128) -> (Self, u128) {
@@ -1103,8 +1148,9 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`i128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         /// This always wraps, which can never happen in practice.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_i128(self, n: i128) -> (Self, i128) {
@@ -1134,7 +1180,8 @@ macro_rules! define {
         /// Get the quotient of our big integer divided
         /// by [`i128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_i128(self, n: i128) -> Self {
@@ -1144,7 +1191,8 @@ macro_rules! define {
         /// Get the remainder of our big integer divided
         /// by [`i128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_i128(self, n: i128) -> i128 {
@@ -1386,7 +1434,8 @@ macro_rules! define {
         /// Add [`u32`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_u32(self, n: u32) -> (Self, bool) {
@@ -1396,7 +1445,7 @@ macro_rules! define {
         /// Add [`i32`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_i32(self, n: i32) -> (Self, bool) {
@@ -1406,7 +1455,7 @@ macro_rules! define {
         /// Subtract [`u32`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_u32(self, n: u32) -> (Self, bool) {
@@ -1416,7 +1465,7 @@ macro_rules! define {
         /// Subtract [`i32`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_i32(self, n: i32) -> (Self, bool) {
@@ -1426,7 +1475,7 @@ macro_rules! define {
         /// Multiply our big integer by [`u32`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_u32(self, n: u32) -> (Self, bool) {
@@ -1436,7 +1485,7 @@ macro_rules! define {
         /// Multiply our big integer by [`i32`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_i32(self, n: i32) -> (Self, bool) {
@@ -1447,7 +1496,7 @@ macro_rules! define {
         /// by [`i32`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_rem_i32(self, n: i32) -> ((Self, i32), bool) {
@@ -1459,7 +1508,7 @@ macro_rules! define {
         /// by [`i32`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_i32(self, n: i32) -> (Self, bool) {
@@ -1470,7 +1519,7 @@ macro_rules! define {
         /// by [`i32`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_i32(self, n: i32) -> (i32, bool) {
@@ -1483,7 +1532,7 @@ macro_rules! define {
         /// Add [`u64`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_u64(self, n: u64) -> (Self, bool) {
@@ -1494,7 +1543,7 @@ macro_rules! define {
         /// Add [`i64`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_i64(self, n: i64) -> (Self, bool) {
@@ -1505,7 +1554,7 @@ macro_rules! define {
         /// Subtract [`u64`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_u64(self, n: u64) -> (Self, bool) {
@@ -1516,7 +1565,7 @@ macro_rules! define {
         /// Subtract [`i64`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_i64(self, n: i64) -> (Self, bool) {
@@ -1527,7 +1576,7 @@ macro_rules! define {
         /// Multiply our big integer by [`u64`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_u64(self, n: u64) -> (Self, bool) {
@@ -1538,7 +1587,7 @@ macro_rules! define {
         /// Multiply our big integer by [`i64`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_i64(self, n: i64) -> (Self, bool) {
@@ -1550,7 +1599,7 @@ macro_rules! define {
         /// by [`i64`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_rem_i64(self, n: i64) -> ((Self, i64), bool) {
@@ -1565,7 +1614,7 @@ macro_rules! define {
         /// by [`i64`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_i64(self, n: i64) -> (Self, bool) {
@@ -1577,7 +1626,7 @@ macro_rules! define {
         /// by [`i64`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_i64(self, n: i64) -> (i64, bool) {
@@ -1590,7 +1639,7 @@ macro_rules! define {
         /// Add [`u128`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_u128(self, n: u128) -> (Self, bool) {
@@ -1611,7 +1660,7 @@ macro_rules! define {
         /// Add [`i128`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_i128(self, n: i128) -> (Self, bool) {
@@ -1632,7 +1681,7 @@ macro_rules! define {
         /// Subtract [`u128`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_u128(self, n: u128) -> (Self, bool) {
@@ -1653,7 +1702,7 @@ macro_rules! define {
         /// Subtract [`i128`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_i128(self, n: i128) -> (Self, bool) {
@@ -1674,7 +1723,7 @@ macro_rules! define {
         /// Multiply our big integer by [`u128`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_u128(self, n: u128) -> (Self, bool) {
@@ -1695,7 +1744,7 @@ macro_rules! define {
         /// Multiply our big integer by [`i128`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_i128(self, n: i128) -> (Self, bool) {
@@ -1717,7 +1766,7 @@ macro_rules! define {
         /// by [`i128`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_rem_i128(self, n: i128) -> ((Self, i128), bool) {
@@ -1740,7 +1789,7 @@ macro_rules! define {
         /// by [`i128`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_i128(self, n: i128) -> (Self, bool) {
@@ -1752,7 +1801,7 @@ macro_rules! define {
         /// by [`i128`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_i128(self, n: i128) -> (i128, bool) {
@@ -1766,7 +1815,7 @@ macro_rules! define {
 
         // LIMB
 
-        /// Add [`ILimb`][crate::ILimb] to the big integer, returning None on overflow.
+        /// Add [`ILimb`][crate::ILimb] to the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -1780,7 +1829,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`ILimb`][crate::ILimb] from the big integer, returning None on overflow.
+        /// Subtract [`ILimb`][crate::ILimb] from the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
         #[inline(always)]
@@ -1794,7 +1843,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`ILimb`][crate::ILimb], returning None on overflow.
+        /// Multiply our big integer by [`ILimb`][crate::ILimb], returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
@@ -1809,7 +1858,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by [`ILimb`][crate::ILimb], returning None on overflow or division by 0.
+        /// by [`ILimb`][crate::ILimb], returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
@@ -1826,7 +1875,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -1836,7 +1885,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -1847,7 +1896,7 @@ macro_rules! define {
 
         // WIDE
 
-        /// Add [`IWide`][crate::IWide] to the big integer, returning None on overflow.
+        /// Add [`IWide`][crate::IWide] to the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::wide_doc!(addition)]
         #[inline(always)]
@@ -1861,7 +1910,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`IWide`][crate::IWide] from the big integer, returning None on overflow.
+        /// Subtract [`IWide`][crate::IWide] from the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::wide_doc!(subtraction)]
         #[inline(always)]
@@ -1875,7 +1924,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`IWide`][crate::IWide], returning None on overflow.
+        /// Multiply our big integer by [`IWide`][crate::IWide], returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::wide_doc!(multiplication)]
         #[inline(always)]
@@ -1890,7 +1939,7 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by [`IWide`][crate::IWide], returning None on overflow or division by 0.
+        /// by [`IWide`][crate::IWide], returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::wide_doc!(division)]
         #[inline]
@@ -1907,7 +1956,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::wide_doc!(division)]
         #[inline(always)]
@@ -1917,7 +1966,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::wide_doc!(division)]
         #[inline(always)]
@@ -1932,27 +1981,30 @@ macro_rules! define {
 
         // U32
 
-        /// Add [`i32`] to the big integer, returning None on overflow.
+        /// Add [`i32`] to the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_i32(self, n: i32) -> Option<Self> {
             self.checked_add_ilimb(n as $crate::ILimb)
         }
 
-        /// Subtract [`i32`] from the big integer, returning None on overflow.
+        /// Subtract [`i32`] from the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_i32(self, n: i32) -> Option<Self> {
             self.checked_sub_ilimb(n as $crate::ILimb)
         }
 
-        /// Multiply our big integer by [`i32`], returning None on overflow.
+        /// Multiply our big integer by [`i32`], returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_i32(self, n: i32) -> Option<Self> {
@@ -1960,9 +2012,10 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by [`i32`], returning None on overflow or division by 0.
+        /// by [`i32`], returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_rem_i32(self, n: i32) -> Option<(Self, i32)> {
@@ -1971,9 +2024,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_i32(self, n: i32) -> Option<Self> {
@@ -1981,9 +2035,10 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_i32(self, n: i32) -> Option<i32> {
@@ -1992,9 +2047,10 @@ macro_rules! define {
 
         // U64
 
-        /// Add [`i64`] to the big integer, returning None on overflow.
+        /// Add [`i64`] to the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_i64(self, n: i64) -> Option<Self> {
@@ -2006,9 +2062,10 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`i64`] from the big integer, returning None on overflow.
+        /// Subtract [`i64`] from the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_i64(self, n: i64) -> Option<Self> {
@@ -2020,9 +2077,10 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`i64`], returning None on overflow.
+        /// Multiply our big integer by [`i64`], returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_i64(self, n: i64) -> Option<Self> {
@@ -2035,9 +2093,10 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by [`i64`], returning None on overflow or division by 0.
+        /// by [`i64`], returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_rem_i64(self, n: i64) -> Option<(Self, i64)> {
@@ -2052,9 +2111,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_i64(self, n: i64) -> Option<Self> {
@@ -2062,9 +2122,10 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_i64(self, n: i64) -> Option<i64> {
@@ -2073,9 +2134,10 @@ macro_rules! define {
 
         // U128
 
-        /// Add [`i128`] to the big integer, returning None on overflow.
+        /// Add [`i128`] to the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_i128(self, n: i128) -> Option<Self> {
@@ -2087,9 +2149,10 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`i128`] from the big integer, returning None on overflow.
+        /// Subtract [`i128`] from the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_i128(self, n: i128) -> Option<Self> {
@@ -2101,9 +2164,10 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`i128`], returning None on overflow.
+        /// Multiply our big integer by [`i128`], returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_i128(self, n: i128) -> Option<Self> {
@@ -2116,9 +2180,10 @@ macro_rules! define {
         }
 
         /// Get the quotient and remainder of our big integer divided
-        /// by [`i128`], returning None on overflow or division by 0.
+        /// by [`i128`], returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_rem_i128(self, n: i128) -> Option<(Self, i128)> {
@@ -2133,9 +2198,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_i128(self, n: i128) -> Option<Self> {
@@ -2143,9 +2209,10 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_i128(self, n: i128) -> Option<i128> {

--- a/src/int/mod.rs
+++ b/src/int/mod.rs
@@ -45,11 +45,13 @@ pub(crate) mod wrapping;
 /// ```
 macro_rules! define {
     (
+        $(#[$attr:meta])?
         name => $name:ident,
         unsigned_t => $u_t:ty,
         bits => $bits:expr  $(,)?
     ) => {
         $crate::shared::int_struct_define!(
+            $(#[$attr])?
             name => $name,
             bits => $bits,
             kind => signed,
@@ -78,7 +80,7 @@ macro_rules! define {
             $crate::int::casts::define!(
                 unsigned_type => $u_t,
                 bits => $bits,
-                wide_type => $crate::IWide,
+                see_type => i64,
                 kind => signed,
             );
             $crate::shared::extensions::define!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,9 +73,11 @@
 //! [`u64`]: https://doc.rust-lang.org/std/primitive.u64.html
 //! [`i256`]: https://crates.io/crates/i256
 
-#![allow(unused_unsafe)]
 #![cfg_attr(feature = "lint", warn(unsafe_op_in_unsafe_fn))]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![allow(unused_unsafe)]
 #![deny(
     clippy::doc_markdown,
     clippy::unnecessary_safety_comment,
@@ -125,16 +127,19 @@ pub use types::{ILimb, IWide, ULimb, UWide};
 /// Both types must have a signed and unsigned variant.
 macro_rules! define {
     (
+        $(#[$attr:meta])?
         unsigned => $unsigned:ident,
         signed => $signed:ident,
         bits => $bits:literal,
     ) => {
         crate::int::define!(
+            $(#[$attr])?
             name => $signed,
             unsigned_t => $unsigned,
             bits => $bits,
         );
         crate::uint::define!(
+            $(#[$attr])?
             name => $unsigned,
             signed_t => $signed,
             bits => $bits,
@@ -149,18 +154,21 @@ define!(
 );
 #[cfg(feature = "i384")]
 define!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "i386")))]
     unsigned => U384,
     signed => I384,
     bits => 384,
 );
 #[cfg(feature = "i512")]
 define!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "i512")))]
     unsigned => U512,
     signed => I512,
     bits => 512,
 );
 #[cfg(feature = "i1024")]
 define!(
+    #[cfg_attr(docsrs, doc(cfg(feature = "i1024")))]
     unsigned => U1024,
     signed => I1024,
     bits => 1024,

--- a/src/shared/docs.rs
+++ b/src/shared/docs.rs
@@ -112,6 +112,19 @@ On overflow, this function will panic if overflow checks are enabled
 pub(crate) use overflow_assertions_doc;
 
 #[rustfmt::skip]
+macro_rules! fixed_doc {
+    ($op:ident) => {
+        concat!(
+"
+This allows optimizations a full ", stringify!($op), " cannot do.
+"
+)
+    };
+}
+
+pub(crate) use fixed_doc;
+
+#[rustfmt::skip]
 macro_rules! limb_doc {
     ($op:ident) => {
         concat!(

--- a/src/shared/limb.rs
+++ b/src/shared/limb.rs
@@ -187,7 +187,8 @@ macro_rules! define {
 
         /// Add [`u32`] to the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_u32(self, n: u32) -> Self {
@@ -203,7 +204,8 @@ macro_rules! define {
 
         /// Subtract [`u32`] from the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_u32(self, n: u32) -> Self {
@@ -219,7 +221,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`u32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_u32(self, n: u32) -> Self {
@@ -236,11 +239,12 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         ///
         /// # Panics
         ///
         /// This panics if the divisor is 0.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_u32(self, n: u32) -> (Self, u32) {
@@ -256,7 +260,8 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by [`u32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_u32(self, n: u32) -> Self {
@@ -265,7 +270,8 @@ macro_rules! define {
 
         /// Get the remainder of our big integer divided by [`u32`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_u32(self, n: u32) -> u32 {
@@ -276,7 +282,8 @@ macro_rules! define {
 
         /// Add [`u64`] to the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_u64(self, n: u64) -> Self {
@@ -292,7 +299,8 @@ macro_rules! define {
 
         /// Subtract [`u64`] from the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_u64(self, n: u64) -> Self {
@@ -308,7 +316,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`u64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_u64(self, n: u64) -> Self {
@@ -325,11 +334,12 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         ///
         /// # Panics
         ///
         /// This panics if the divisor is 0.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_u64(self, n: u64) -> (Self, u64) {
@@ -345,7 +355,8 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by [`u64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_u64(self, n: u64) -> Self {
@@ -354,7 +365,8 @@ macro_rules! define {
 
         /// Get the remainder of our big integer divided by [`u64`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_u64(self, n: u64) -> u64 {
@@ -365,7 +377,8 @@ macro_rules! define {
 
          /// Add [`u128`] to the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn add_u128(self, n: u128) -> Self {
@@ -381,7 +394,8 @@ macro_rules! define {
 
         /// Subtract [`u128`] from the big integer.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn sub_u128(self, n: u128) -> Self {
@@ -397,7 +411,8 @@ macro_rules! define {
 
         /// Multiply our big integer by [`u128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn mul_u128(self, n: u128) -> Self {
@@ -414,11 +429,12 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         ///
         /// # Panics
         ///
         /// This panics if the divisor is 0.
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_rem_u128(self, n: u128) -> (Self, u128) {
@@ -434,7 +450,8 @@ macro_rules! define {
 
         /// Get the quotient of our big integer divided by [`u128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn div_u128(self, n: u128) -> Self {
@@ -443,7 +460,8 @@ macro_rules! define {
 
         /// Get the remainder of our big integer divided by [`u128`].
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn rem_u128(self, n: u128) -> u128 {
@@ -504,7 +522,8 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by [`u32`],
         /// wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_u32(self, n: u32) -> Self {
@@ -514,7 +533,8 @@ macro_rules! define {
         /// Get the remainder of our big integer divided by [`u32`],
         /// wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_u32(self, n: u32) -> u32 {
@@ -526,7 +546,8 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by [`u64`],
         /// wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_u64(self, n: u64) -> Self {
@@ -536,7 +557,8 @@ macro_rules! define {
         /// Get the remainder of our big integer divided by [`u64`],
         /// wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_u64(self, n: u64) -> u64 {
@@ -548,7 +570,8 @@ macro_rules! define {
         /// Get the quotient of our big integer divided by [`u128`],
         /// wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_u128(self, n: u128) -> Self {
@@ -558,7 +581,8 @@ macro_rules! define {
         /// Get the remainder of our big integer divided by [`u128`],
         /// wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::wide_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_rem_u128(self, n: u128) -> u128 {
@@ -647,7 +671,8 @@ macro_rules! define {
         /// by [`u32`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         pub fn overflowing_div_rem_u32(self, n: u32) -> ((Self, u32), bool) {
             (self.wrapping_div_rem_u32(n), false)
@@ -657,7 +682,8 @@ macro_rules! define {
         /// by [`u32`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_u32(self, n: u32) -> (Self, bool) {
@@ -669,7 +695,8 @@ macro_rules! define {
         /// by [`u32`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_u32(self, n: u32) -> (u32, bool) {
@@ -683,7 +710,8 @@ macro_rules! define {
         /// by [`u64`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         pub fn overflowing_div_rem_u64(self, n: u64) -> ((Self, u64), bool) {
             (self.wrapping_div_rem_u64(n), false)
@@ -693,7 +721,8 @@ macro_rules! define {
         /// by [`u64`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_u64(self, n: u64) -> (Self, bool) {
@@ -705,7 +734,8 @@ macro_rules! define {
         /// by [`u64`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_u64(self, n: u64) -> (u64, bool) {
@@ -719,7 +749,8 @@ macro_rules! define {
         /// by [`u128`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         pub fn overflowing_div_rem_u128(self, n: u128) -> ((Self, u128), bool) {
             (self.wrapping_div_rem_u128(n), false)
@@ -729,7 +760,8 @@ macro_rules! define {
         /// by [`u128`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_div_u128(self, n: u128) -> (Self, bool) {
@@ -741,7 +773,8 @@ macro_rules! define {
         /// by [`u128`], returning the value and if overflow
         /// occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn overflowing_rem_u128(self, n: u128) -> (u128, bool) {
@@ -753,7 +786,7 @@ macro_rules! define {
     (@checked) => {
         // LIMB
 
-        /// Add [`ULimb`][crate::ULimb] to the big integer, returning None on overflow.
+        /// Add [`ULimb`][crate::ULimb] to the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -767,7 +800,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`ULimb`][crate::ULimb] from the big integer, returning None on overflow.
+        /// Subtract [`ULimb`][crate::ULimb] from the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
         #[inline(always)]
@@ -781,7 +814,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`ULimb`][crate::ULimb], returning None on overflow.
+        /// Multiply our big integer by [`ULimb`][crate::ULimb], returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::limb_doc!(multiplication)]
         #[inline(always)]
@@ -796,7 +829,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline]
@@ -809,7 +842,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -819,7 +852,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::limb_doc!(division)]
         #[inline(always)]
@@ -830,7 +863,7 @@ macro_rules! define {
 
         // WIDE
 
-        /// Add [`UWide`][crate::UWide] to the big integer, returning None on overflow.
+        /// Add [`UWide`][crate::UWide] to the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::wide_doc!(addition)]
         #[inline(always)]
@@ -844,7 +877,7 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`UWide`][crate::UWide] from the big integer, returning None on overflow.
+        /// Subtract [`UWide`][crate::UWide] from the big integer, returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::wide_doc!(addition)]
         #[inline(always)]
@@ -858,7 +891,7 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`UWide`][crate::UWide], returning None on overflow.
+        /// Multiply our big integer by [`UWide`][crate::UWide], returning `None` on overflow.
         ///
         #[doc = $crate::shared::docs::wide_doc!(multiplication)]
         #[inline(always)]
@@ -873,7 +906,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::wide_doc!(division)]
         #[inline]
@@ -886,7 +919,7 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::wide_doc!(division)]
         #[inline(always)]
@@ -896,7 +929,7 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
         #[doc = $crate::shared::docs::wide_doc!(division)]
         #[inline(always)]
@@ -909,9 +942,10 @@ macro_rules! define {
     (@checked-fixed) => {
         // U32
 
-        /// Add [`u32`] to the big integer, returning None on overflow.
+        /// Add [`u32`] to the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_u32(self, n: u32) -> Option<Self> {
@@ -923,9 +957,10 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`u32`] from the big integer, returning None on overflow.
+        /// Subtract [`u32`] from the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_u32(self, n: u32) -> Option<Self> {
@@ -937,9 +972,10 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`u32`], returning None on overflow.
+        /// Multiply our big integer by [`u32`], returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_u32(self, n: u32) -> Option<Self> {
@@ -952,9 +988,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         pub fn checked_div_rem_u32(self, n: u32) -> Option<(Self, u32)> {
             if n == 0 {
@@ -965,9 +1002,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_u32(self, n: u32) -> Option<Self> {
@@ -975,9 +1013,10 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_u32(self, n: u32) -> Option<u32> {
@@ -986,9 +1025,10 @@ macro_rules! define {
 
         // U64
 
-        /// Add [`u64`] to the big integer, returning None on overflow.
+        /// Add [`u64`] to the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_u64(self, n: u64) -> Option<Self> {
@@ -1000,9 +1040,10 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`u64`] from the big integer, returning None on overflow.
+        /// Subtract [`u64`] from the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_u64(self, n: u64) -> Option<Self> {
@@ -1014,9 +1055,10 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`u64`], returning None on overflow.
+        /// Multiply our big integer by [`u64`], returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_u64(self, n: u64) -> Option<Self> {
@@ -1029,9 +1071,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         pub fn checked_div_rem_u64(self, n: u64) -> Option<(Self, u64)> {
             if n == 0 {
@@ -1042,9 +1085,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_u64(self, n: u64) -> Option<Self> {
@@ -1052,9 +1096,10 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_u64(self, n: u64) -> Option<u64> {
@@ -1063,9 +1108,10 @@ macro_rules! define {
 
         // U128
 
-        /// Add [`u128`] to the big integer, returning None on overflow.
+        /// Add [`u128`] to the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_add_u128(self, n: u128) -> Option<Self> {
@@ -1077,9 +1123,10 @@ macro_rules! define {
             }
         }
 
-        /// Subtract [`u128`] from the big integer, returning None on overflow.
+        /// Subtract [`u128`] from the big integer, returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_sub_u128(self, n: u128) -> Option<Self> {
@@ -1091,9 +1138,10 @@ macro_rules! define {
             }
         }
 
-        /// Multiply our big integer by [`u128`], returning None on overflow.
+        /// Multiply our big integer by [`u128`], returning `None` on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn checked_mul_u128(self, n: u128) -> Option<Self> {
@@ -1106,9 +1154,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline]
         pub fn checked_div_rem_u128(self, n: u128) -> Option<(Self, u128)> {
             if n == 0 {
@@ -1119,9 +1168,10 @@ macro_rules! define {
         }
 
         /// Get the quotient of our big integer divided by an unsigned
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_div_u128(self, n: u128) -> Option<Self> {
@@ -1129,9 +1179,10 @@ macro_rules! define {
         }
 
         /// Get the remainder of our big integer divided by a signed
-        /// limb, returning None on overflow or division by 0.
+        /// limb, returning `None` on overflow or division by 0.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn checked_rem_u128(self, n: u128) -> Option<u128> {

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod wrapping;
 #[rustfmt::skip]
 macro_rules! int_struct_define {
     (
+        $(#[$attr:meta])?
         name => $name:ident,
         bits => $bits:literal,
         kind => $kind:ident $(,)?
@@ -53,6 +54,7 @@ macro_rules! int_struct_define {
         ///
         #[doc = concat!("[`to_le_bytes`]: ", stringify!($name), "::to_le_bytes")]
         #[doc = concat!("[`to_be_bytes`]: ", stringify!($name), "::to_be_bytes")]
+        $(#[$attr])?
         /// [`alternate`]: core::fmt::Formatter::alternate
         /// [`Binary`]: core::fmt::Binary
         /// [`128-bit`]: https://rust-lang.github.io/unsafe-code-guidelines/layout/scalars.html#fixed-width-integer-types

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,9 @@
 #[rustfmt::skip]
 macro_rules! limb_doc {
     () => {
+// a blank line to avoid a large first paragraph in the generated docs
 "
+
 This is guaranteed to have optimal performance for big integer
 to scalar operations, however, the type size may be 32 or
 64 bits depending on the architecture and pointer size.
@@ -44,7 +46,9 @@ performance if the bits in the type used is larger than the limb.
 #[rustfmt::skip]
 macro_rules! wide_doc {
     () => {
+// a blank line to avoid a large first paragraph in the generated docs
 "
+
 The performance of wide (double the bits of the limb) can be highly
 variable: for addition, multiplication, and subtraction it can be
 as fast as operations with limbs, however, the worst case performance

--- a/src/uint/casts.rs
+++ b/src/uint/casts.rs
@@ -5,7 +5,7 @@ macro_rules! define {
     (
         signed_type => $s_t:ty,
         bits => $bits:expr,
-        wide_type => $wide_t:ty,
+        see_type => $see_t:ty,
         kind => $kind:ident $(,)?
     ) => {
         $crate::shared::casts::define!(
@@ -21,7 +21,7 @@ macro_rules! define {
         /// This produces the same result as an `as` cast, but ensures that the
         /// bit-width remains the same.
         ///
-        #[doc = $crate::shared::docs::primitive_doc!(u128, cast_signed)]
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, cast_signed)]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn cast_signed(self) -> $s_t {

--- a/src/uint/limb.rs
+++ b/src/uint/limb.rs
@@ -182,7 +182,8 @@ macro_rules! define {
         /// Add [`u32`] to the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_u32(self, n: u32) -> Self {
@@ -192,7 +193,8 @@ macro_rules! define {
         /// Subtract [`u32`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_u32(self, n: u32) -> Self {
@@ -202,7 +204,8 @@ macro_rules! define {
         /// Multiply our big integer by [`u32`], wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_u32(self, n: u32) -> Self {
@@ -212,9 +215,10 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u32`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_u32(self, n: u32) -> (Self, u32) {
@@ -227,7 +231,8 @@ macro_rules! define {
         /// Add [`u64`] to the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_u64(self, n: u64) -> Self {
@@ -238,7 +243,8 @@ macro_rules! define {
         /// Subtract [`u64`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_u64(self, n: u64) -> Self {
@@ -249,7 +255,8 @@ macro_rules! define {
         /// Multiply our big integer by [`u64`], wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_u64(self, n: u64) -> Self {
@@ -260,9 +267,10 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u64`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_u64(self, n: u64) -> (Self, u64) {
@@ -282,7 +290,8 @@ macro_rules! define {
         /// Add [`u128`] to the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_add_u128(self, n: u128) -> Self {
@@ -302,7 +311,8 @@ macro_rules! define {
         /// Subtract [`u128`] from the big integer, wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_sub_u128(self, n: u128) -> Self {
@@ -322,7 +332,8 @@ macro_rules! define {
         /// Multiply our big integer by [`u128`], wrapping on
         /// overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn wrapping_mul_u128(self, n: u128) -> Self {
@@ -342,9 +353,10 @@ macro_rules! define {
         /// Get the quotient and remainder of our big integer divided
         /// by [`u128`], wrapping on overflow.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(division)]
+        #[doc = $crate::shared::docs::fixed_doc!(division)]
         ///
         #[doc = $crate::shared::docs::div_by_zero_doc!(n)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub fn wrapping_div_rem_u128(self, n: u128) -> (Self, u128) {
@@ -371,6 +383,7 @@ macro_rules! define {
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
@@ -382,6 +395,7 @@ macro_rules! define {
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
@@ -412,6 +426,7 @@ macro_rules! define {
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         /// [`wrapping_mul_ulimb`]: Self::wrapping_mul_ulimb
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_ulimb(self, n: $crate::ULimb) -> (Self, bool) {
@@ -425,6 +440,7 @@ macro_rules! define {
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::wide_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_uwide(self, n: $crate::UWide) -> (Self, bool) {
@@ -436,6 +452,7 @@ macro_rules! define {
         /// and if overflow occurred.
         ///
         #[doc = $crate::shared::docs::wide_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_uwide(self, n: $crate::UWide) -> (Self, bool) {
@@ -466,6 +483,7 @@ macro_rules! define {
         ///
         /// [`mulx`]: https://www.felixcloutier.com/x86/mulx
         /// [`wrapping_mul_uwide`]: Self::wrapping_mul_uwide
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_uwide(self, n: $crate::UWide) -> (Self, bool) {
@@ -482,7 +500,8 @@ macro_rules! define {
         /// Add [`u32`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_u32(self, n: u32) -> (Self, bool) {
@@ -492,7 +511,8 @@ macro_rules! define {
         /// Subtract [`u32`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_u32(self, n: u32) -> (Self, bool) {
@@ -502,7 +522,8 @@ macro_rules! define {
         /// Multiply our big integer by [`u32`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_u32(self, n: u32) -> (Self, bool) {
@@ -514,7 +535,8 @@ macro_rules! define {
         /// Add [`u64`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_u64(self, n: u64) -> (Self, bool) {
@@ -525,7 +547,8 @@ macro_rules! define {
         /// Subtract [`u64`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_u64(self, n: u64) -> (Self, bool) {
@@ -536,7 +559,8 @@ macro_rules! define {
         /// Multiply our big integer by [`u64`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_u64(self, n: u64) -> (Self, bool) {
@@ -549,7 +573,8 @@ macro_rules! define {
         /// Add [`u128`] to the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(addition)]
+        #[doc = $crate::shared::docs::fixed_doc!(addition)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_add_u128(self, n: u128) -> (Self, bool) {
@@ -569,7 +594,8 @@ macro_rules! define {
         /// Subtract [`u128`] from the big integer, returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(subtraction)]
+        #[doc = $crate::shared::docs::fixed_doc!(subtraction)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_sub_u128(self, n: u128) -> (Self, bool) {
@@ -589,7 +615,8 @@ macro_rules! define {
         /// Multiply our big integer by [`u128`], returning the value
         /// and if overflow occurred.
         ///
-        #[doc = $crate::shared::docs::limb_doc!(multiplication)]
+        #[doc = $crate::shared::docs::fixed_doc!(multiplication)]
+        #[cfg_attr(docsrs, doc(cfg(feature = "stdint")))]
         #[inline(always)]
         #[must_use = $crate::shared::docs::must_use_copy_doc!()]
         pub const fn overflowing_mul_u128(self, n: u128) -> (Self, bool) {

--- a/src/uint/mod.rs
+++ b/src/uint/mod.rs
@@ -40,11 +40,13 @@ pub(crate) mod wrapping;
 /// ```
 macro_rules! define {
     (
+        $(#[$attr:meta])?
         name => $name:ident,
         signed_t => $s_t:ty,
         bits => $bits:expr $(,)?
     ) => {
         $crate::shared::int_struct_define!(
+            $(#[$attr])?
             name => $name,
             bits => $bits,
             kind => unsigned,
@@ -73,7 +75,7 @@ macro_rules! define {
             $crate::uint::casts::define!(
                 signed_type => $s_t,
                 bits => $bits,
-                wide_type => $crate::UWide,
+                see_type => u64,
                 kind => unsigned,
             );
             $crate::uint::extensions::define!(


### PR DESCRIPTION
1. Mark all methods that require the `stdint` feature:
![image](https://github.com/user-attachments/assets/6c71453b-5c81-40fc-aed5-3e0641270bbd)
(note, it should be produced automatically by `feature(doc_auto_cfg)`, but it doesn't propagate this info for complex statements like `#[cfg(feature = X)] define!()`, so we mark it directly)

2. Remove unrelated information about limbs from those docstrings.

3. Mark `iXXX` structs:
![image](https://github.com/user-attachments/assets/994688fc-730c-4d6c-a5b9-97a8cd67f69b)

4. Fix broken links in `cast_signed` and `cast_unsigned` docstrings.