### PR TITLE
Support `num-traits`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        features: ["limb32", "stdint", "limb32,stdint"]
+        features: ["limb32", "stdint", "limb32,stdint", "num-traits,limb32", "num-traits,stdint", "num-traits,limb32,stdint", ]
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,12 @@ jobs:
       uses: dtolnay/rust-toolchain@nightly
 
     - name: Check
-      run: cargo check --features=limb32
+      run: cargo check --no-default-features --features=${{ matrix.features }}
 
     - name: Test
-      run: cargo test --features=limb32
+      run: cargo test --no-default-features --features=${{ matrix.features }}
 
     - name: Run Quickcheck Tests
       run: |
         cd devel
-        cargo  test --features=limb32
+        cargo  test --no-default-features --features=${{ matrix.features }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Cargo.lock
 TODO.md
 *.profraw
 tarpaulin-report.html
+i256-rs.code-workspace

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -49,6 +49,27 @@
         {
             "type": "lldb",
             "request": "launch",
+            "name": "num-traits support",
+            "cargo": {
+                "args": [
+                    "+nightly",
+                    "test",
+                    "--no-run",
+                    "--features=num-traits",
+                    "--lib",
+                    "--package=i256"
+                ],
+                "filter": {
+                    "name": "i256",
+                    "kind": "lib"
+                }
+            },
+            "args": [],
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "type": "lldb",
+            "request": "launch",
             "name": "1.59.0 Support",
             "cargo": {
                 "args": [

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Added
+
+- Optional support for `num-traits`, implementing that crate's integer arithmetic and conversion traits for all provided integer types.
+
 ## [0.2.1] 2025-01-05
 
 ## Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,7 @@ exclude = [
 ]
 
 [features]
-default = ["std", "stdint"]
-std = []
+default = ["stdint"]
 # enable the standard, fixed-width integer APIs for scalar operations.
 stdint = []
 # Enable the `U384` and `I384` types.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,9 @@ debug = false
 debug-assertions = false
 lto = true
 
+[dependencies]
+num-traits = { version = "0.2.18", default-features = false, optional = true }
+
 [package.metadata.docs.rs]
-features = ["i384", "i512", "i1024", "stdint"]
+features = ["i384", "i512", "i1024", "stdint", "num-traits"]
 rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ noasm = []
 # For forcing 32-bit limbs for testing.
 limb32 = []
 
+# Deprecated feature; does nothing.
+std = []
+
 [lints.rust.unexpected_cfgs]
 level = "warn"
 check-cfg = [

--- a/devel/Cargo.toml
+++ b/devel/Cargo.toml
@@ -6,9 +6,8 @@ edition = "2021"
 publish = false
 
 [features]
-std = ["i256/std"]
 stdint = ["i256/stdint"]
-default = ["std", "stdint"]
+default = ["stdint"]
 noasm = ["i256/noasm"]
 limb32 = ["i256/limb32"]
 "print-benches" = ["serde", "serde_json", "owo-colors"]

--- a/devel/Cargo.toml
+++ b/devel/Cargo.toml
@@ -7,6 +7,7 @@ publish = false
 
 [features]
 stdint = ["i256/stdint"]
+num-traits = ["i256/num-traits"]
 default = ["stdint"]
 noasm = ["i256/noasm"]
 limb32 = ["i256/limb32"]

--- a/src/int/traits.rs
+++ b/src/int/traits.rs
@@ -139,6 +139,374 @@ macro_rules! define {
                 }
             }
         }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::Signed for $t {
+            #[inline(always)]
+            fn abs(&self) -> Self {
+                Self::abs(*self)
+            }
+
+            #[inline]
+            fn abs_sub(&self, other: &Self) -> Self {
+                if self < other {
+                    <Self as ::num_traits::ConstZero>::ZERO
+                } else {
+                    *self - *other
+                }
+            }
+
+            #[inline]
+            fn signum(&self) -> Self {
+                if *self == <Self as ::num_traits::ConstZero>::ZERO {
+                    <Self as ::num_traits::ConstZero>::ZERO
+                } else if *self > <Self as ::num_traits::ConstZero>::ZERO {
+                    <Self as ::num_traits::ConstOne>::ONE
+                } else {
+                    -<Self as ::num_traits::ConstOne>::ONE
+                }
+            }
+
+            #[inline(always)]
+            fn is_positive(&self) -> bool {
+                *self >= <Self as ::num_traits::ConstZero>::ZERO
+            }
+
+            #[inline(always)]
+            fn is_negative(&self) -> bool {
+                *self < <Self as ::num_traits::ConstZero>::ZERO
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::FromPrimitive for $t {
+            #[inline(always)]
+            fn from_i8(n: i8) -> Option<Self> {
+                Some(Self::from_i8(n))
+            }
+
+            #[inline(always)]
+            fn from_i16(n: i16) -> Option<Self> {
+                Some(Self::from_i16(n))
+            }
+
+            #[inline(always)]
+            fn from_i32(n: i32) -> Option<Self> {
+                Some(Self::from_i32(n))
+            }
+
+            #[inline(always)]
+            fn from_i64(n: i64) -> Option<Self> {
+                Some(Self::from_i64(n))
+            }
+
+            #[inline(always)]
+            fn from_i128(n: i128) -> Option<Self> {
+                Some(Self::from_i128(n))
+            }
+
+            #[inline(always)]
+            fn from_isize(n: isize) -> Option<Self> {
+                Some(Self::from_i128(n as i128))
+            }
+
+            #[inline(always)]
+            fn from_u8(n: u8) -> Option<Self> {
+                Some(Self::from_u8(n))
+            }
+
+            #[inline(always)]
+            fn from_u16(n: u16) -> Option<Self> {
+                Some(Self::from_u16(n))
+            }
+
+            #[inline(always)]
+            fn from_u32(n: u32) -> Option<Self> {
+                Some(Self::from_u32(n))
+            }
+
+            #[inline(always)]
+            fn from_u64(n: u64) -> Option<Self> {
+                Some(Self::from_u64(n))
+            }
+
+            #[inline(always)]
+            fn from_u128(n: u128) -> Option<Self> {
+                Some(Self::from_u128(n))
+            }
+
+            #[inline(always)]
+            fn from_usize(n: usize) -> Option<Self> {
+                Some(Self::from_u128(n as u128))
+            }
+
+            #[inline(always)]
+            fn from_f32(_: f32) -> Option<Self> {
+                unimplemented!("floating-point conversions")
+            }
+
+            #[inline(always)]
+            fn from_f64(_: f64) -> Option<Self> {
+                unimplemented!("floating-point conversions")
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::ToPrimitive for $t {
+            #[inline]
+            fn to_i8(&self) -> Option<i8> {
+                const ABOVE: $t = <$t>::from_i8(i8::MAX);
+                const BELOW: $t = <$t>::from_i8(i8::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_i8(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i16(&self) -> Option<i16> {
+                const ABOVE: $t = <$t>::from_i16(i16::MAX);
+                const BELOW: $t = <$t>::from_i16(i16::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_i16(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i32(&self) -> Option<i32> {
+                const ABOVE: $t = <$t>::from_i32(i32::MAX);
+                const BELOW: $t = <$t>::from_i32(i32::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_i32(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i64(&self) -> Option<i64> {
+                const ABOVE: $t = <$t>::from_i64(i64::MAX);
+                const BELOW: $t = <$t>::from_i64(i64::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_i64(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i128(&self) -> Option<i128> {
+                const ABOVE: $t = <$t>::from_i128(i128::MAX);
+                const BELOW: $t = <$t>::from_i128(i128::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_i128(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_isize(&self) -> Option<isize> {
+                const ABOVE: $t = <$t>::from_i128(isize::MAX as i128);
+                const BELOW: $t = <$t>::from_i128(isize::MIN as i128);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_i128(self) as isize)
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u8(&self) -> Option<u8> {
+                const ABOVE: $t = <$t>::from_u8(u8::MAX);
+                const BELOW: $t = <$t>::from_u8(u8::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_u8(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u16(&self) -> Option<u16> {
+                const ABOVE: $t = <$t>::from_u16(u16::MAX);
+                const BELOW: $t = <$t>::from_u16(u16::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_u16(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u32(&self) -> Option<u32> {
+                const ABOVE: $t = <$t>::from_u32(u32::MAX);
+                const BELOW: $t = <$t>::from_u32(u32::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_u32(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u64(&self) -> Option<u64> {
+                const ABOVE: $t = <$t>::from_u64(u64::MAX);
+                const BELOW: $t = <$t>::from_u64(u64::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_u64(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u128(&self) -> Option<u128> {
+                const ABOVE: $t = <$t>::from_u128(u128::MAX);
+                const BELOW: $t = <$t>::from_u128(u128::MIN);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_u128(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_usize(&self) -> Option<usize> {
+                const ABOVE: $t = <$t>::from_u128(usize::MAX as u128);
+                const BELOW: $t = <$t>::from_u128(usize::MIN as u128);
+                if *self <= ABOVE && *self >= BELOW {
+                    Some(Self::as_u128(self) as usize)
+                } else {
+                    None
+                }
+            }
+
+            #[inline(always)]
+            fn to_f32(&self) -> Option<f32> {
+                unimplemented!("floating-point conversions")
+            }
+
+            #[inline(always)]
+            fn to_f64(&self) -> Option<f64> {
+                unimplemented!("floating-point conversions")
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::NumCast for $t {
+            #[inline]
+            fn from<T: ::num_traits::ToPrimitive>(n: T) -> Option<Self> {
+                if let Some(n128i) = <T as ::num_traits::ToPrimitive>::to_i128(&n) {
+                    <Self as ::num_traits::FromPrimitive>::from_i128(n128i)
+                } else if let Some(n128u) = <T as ::num_traits::ToPrimitive>::to_u128(&n) {
+                    <Self as ::num_traits::FromPrimitive>::from_u128(n128u)
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::PrimInt for $t {
+            #[inline(always)]
+            fn count_ones(self) -> u32 {
+                Self::count_ones(self)
+            }
+
+            #[inline(always)]
+            fn count_zeros(self) -> u32 {
+                Self::count_zeros(self)
+            }
+
+            #[inline(always)]
+            fn leading_ones(self) -> u32 {
+                Self::leading_ones(self)
+            }
+
+            #[inline(always)]
+            fn leading_zeros(self) -> u32 {
+                Self::leading_zeros(self)
+            }
+
+            #[inline(always)]
+            fn trailing_ones(self) -> u32 {
+                Self::trailing_ones(self)
+            }
+
+            #[inline(always)]
+            fn trailing_zeros(self) -> u32 {
+                Self::trailing_zeros(self)
+            }
+
+            #[inline(always)]
+            fn rotate_left(self, n: u32) -> Self {
+                Self::rotate_left(self, n)
+            }
+
+            #[inline(always)]
+            fn rotate_right(self, n: u32) -> Self {
+                Self::rotate_right(self, n)
+            }
+
+            #[inline(always)]
+            fn signed_shl(self, n: u32) -> Self {
+                self << n
+            }
+
+            #[inline(always)]
+            fn signed_shr(self, n: u32) -> Self {
+                self >> n
+            }
+
+            #[inline(always)]
+            fn unsigned_shl(self, n: u32) -> Self {
+                (self.cast_unsigned() << n).cast_signed()
+            }
+
+            #[inline(always)]
+            fn unsigned_shr(self, n: u32) -> Self {
+                (self.cast_unsigned() >> n).cast_signed()
+            }
+
+            #[inline(always)]
+            fn swap_bytes(self) -> Self {
+                Self::swap_bytes(&self)
+            }
+
+            #[inline(always)]
+            fn from_be(x: Self) -> Self {
+                Self::from_be(x)
+            }
+
+            #[inline(always)]
+            fn from_le(x: Self) -> Self {
+                Self::from_le(x)
+            }
+
+            #[inline(always)]
+            fn to_be(self) -> Self {
+                Self::to_be(self)
+            }
+
+            #[inline(always)]
+            fn to_le(self) -> Self {
+                Self::to_le(self)
+            }
+
+            #[inline(always)]
+            fn reverse_bits(self) -> Self {
+                Self::reverse_bits(&self)
+            }
+
+            #[inline(always)]
+            fn pow(self, exp: u32) -> Self {
+                Self::pow(self, exp)
+            }
+        }
     };
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //! ## Features
 //!
 //! This crate is optimized for small variants of big integers, but a few
-//! additional types can be enabled via the following features:
+//! additional types or functions can be enabled via the following features:
 #![cfg_attr(feature = "i384", doc = "- `i384`: Add the 384-bit [`I384`] and [`U384`] types.")]
 #![cfg_attr(not(feature = "i384"), doc = "- `i384`: Add the 384-bit `I384` and `U384` types.")]
 #![cfg_attr(feature = "i512", doc = "- `i512`: Add the 512-bit [`I512`] and [`U512`] types.")]
@@ -29,6 +29,13 @@
 //! more expensive on 32-bit architectures): enabling this API adds in overloads
 //! for [`u32`], [`u64`], and [`u128`], guaranteeing API stability across all
 //! platforms.
+//! - `num-traits`: Implement traits from the [`num-traits`] crate for all
+//!   integer types provided by this crate.  Floating-point conversion methods
+//!   are unimplemented and will panic.  The `NumCast` trait and `cast`
+//!   function, by their nature, will not be able cast values above what's
+//!   supported by [`u128`] or [`i128`], even when casting between types
+//!   supplied by this crate.  All other traits and methods from [`num-traits`]
+//!   will behave as expected.
 //!
 //! If you need larger integers, [`crypto-bigint`] has high-performance
 //! addition, subtraction, and multiplication. With integers with a large
@@ -68,6 +75,7 @@
 //! [`crypto-bigint`]: https://crates.io/crates/crypto-bigint
 //! [`bnum`]: https://crates.io/crates/bnum
 //! [`num-bigint`]: https://crates.io/crates/num-bigint
+//! [`num-traits`]: https://crates.io/crates/num-traits
 //! [`malachite`]: https://crates.io/crates/malachite
 //! [`rug`]: https://crates.io/crates/rug
 //! [`u64`]: https://doc.rust-lang.org/std/primitive.u64.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@
 //! [`i256`]: https://crates.io/crates/i256
 
 #![cfg_attr(feature = "lint", warn(unsafe_op_in_unsafe_fn))]
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(test), no_std)]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![allow(unused_unsafe)]

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod docs;
 pub(crate) mod endian;
 pub(crate) mod extensions;
 pub(crate) mod limb;
+pub(crate) mod num_traits_impls;
 pub(crate) mod ops;
 pub(crate) mod ord;
 pub(crate) mod overflowing;

--- a/src/shared/num_traits_impls.rs
+++ b/src/shared/num_traits_impls.rs
@@ -1,0 +1,301 @@
+#[cfg(not(feature = "num-traits"))]
+macro_rules! define {
+    (type => $t:ty,) => {};
+}
+
+#[cfg(feature = "num-traits")]
+macro_rules! define {
+    // implementation of a 2-arg op trait
+    (arity 2, $(
+        type => $t:ty,
+        impl => $trait:ident $(:: $ns1:ident)*,
+        op => $op:ident,
+        out => $out:ty,
+    )*) => {$(
+        impl $trait $(::$ns1)* for $t {
+            #[inline(always)]
+            fn $op(&self, rhs: &Self) -> $out {
+                Self::$op(*self, *rhs)
+            }
+        }
+    )*};
+
+    // implementation of a 1-arg op trait
+    (arity 1, $(
+        type => $t:ty,
+        impl => $trait:ident $(:: $ns1:ident)*,
+        op => $op:ident,
+        out => $out:ty,
+    )*) => {$(
+        impl $trait $(::$ns1)* for $t {
+            #[inline(always)]
+            fn $op(&self) -> $out {
+                Self::$op(*self)
+            }
+        }
+    )*};
+
+    // implementation of a shift-like op trait
+    (arity shift, $(
+        type => $t:ty,
+        impl => $trait:ident $(:: $ns1:ident)*,
+        op => $op:ident,
+        out => $out:ty,
+    )*) => {$(
+        impl $trait $(::$ns1)* for $t {
+            #[inline(always)]
+            fn $op(&self, rhs: u32) -> $out {
+                Self::$op(*self, rhs)
+            }
+        }
+    )*};
+
+    // implementation of AsPrimitive, outbound
+    (impl AsPrimitive, $(
+        in => $in:ty,
+        out => $out:ty,
+        asop => $op:ident,
+        $(extras => as $cast:ty,)?
+    )*) => {$(
+        impl ::num_traits::AsPrimitive<$out> for $in {
+            fn as_(self) -> $out {
+                <$in>::$op(&self) $(as $cast)?
+            }
+        }
+    )*};
+
+    // implementation of AsPrimitive, inbound
+    (impl AsPrimitive, $(
+        in => $in:ty,
+        out => $out:ty,
+        fromop => $op:ident,
+        $(extras => as $cast:ty,)?
+    )*) => {$(
+        impl ::num_traits::AsPrimitive<$out> for $in {
+            fn as_(self) -> $out {
+                <$out>::$op(self $(as $cast)?)
+            }
+        }
+    )*};
+
+    // overall definition
+    (
+        type => $t:ty,
+    ) => {
+        impl ::num_traits::FromBytes for $t {
+            type Bytes = [u8; <$t>::BYTES];
+
+            #[inline(always)]
+            fn from_be_bytes(bytes: &Self::Bytes) -> Self {
+                Self::from_be_bytes(*bytes)
+            }
+
+            #[inline(always)]
+            fn from_le_bytes(bytes: &Self::Bytes) -> Self {
+                Self::from_le_bytes(*bytes)
+            }
+        }
+
+        impl ::num_traits::ToBytes for $t {
+            type Bytes = [u8; <$t>::BYTES];
+
+            #[inline(always)]
+            fn to_be_bytes(&self) -> Self::Bytes {
+                Self::to_be_bytes(*self)
+            }
+
+            #[inline(always)]
+            fn to_le_bytes(&self) -> Self::Bytes {
+                Self::to_le_bytes(*self)
+            }
+        }
+
+        impl ::num_traits::Bounded for $t {
+            #[inline(always)]
+            fn min_value() -> Self {
+                Self::MIN
+            }
+
+            #[inline(always)]
+            fn max_value() -> Self {
+                Self::MAX
+            }
+        }
+
+        impl ::num_traits::Zero for $t {
+            #[inline(always)]
+            fn zero() -> Self {
+                <Self as ::num_traits::ConstZero>::ZERO
+            }
+
+            #[inline(always)]
+            fn is_zero(&self) -> bool {
+                *self == <Self as ::num_traits::ConstZero>::ZERO
+            }
+        }
+
+        impl ::num_traits::ConstZero for $t {
+            const ZERO: Self = Self::from_u8(0);
+        }
+
+        impl ::num_traits::One for $t {
+            #[inline(always)]
+            fn one() -> Self {
+                <Self as ::num_traits::ConstOne>::ONE
+            }
+
+            #[inline(always)]
+            fn is_one(&self) -> bool {
+                *self == <Self as ::num_traits::ConstOne>::ONE
+            }
+        }
+
+        impl ::num_traits::ConstOne for $t {
+            const ONE: Self = Self::from_u8(1);
+        }
+
+        impl ::num_traits::MulAdd for $t {
+            type Output = Self;
+
+            #[inline]
+            fn mul_add(self, a: Self, b: Self) -> Self {
+                (self * a) + b
+            }
+        }
+
+        impl ::num_traits::MulAddAssign for $t {
+            #[inline(always)]
+            fn mul_add_assign(&mut self, a: Self, b: Self) {
+                *self = <Self as ::num_traits::MulAdd>::mul_add(*self, a, b)
+            }
+        }
+
+        impl ::num_traits::Pow<u32> for $t {
+            type Output = Self;
+
+            #[inline(always)]
+            fn pow(self, exp: u32) -> Self {
+                Self::pow(self, exp)
+            }
+        }
+
+        impl ::num_traits::Pow<&u32> for $t {
+            type Output = Self;
+
+            #[inline(always)]
+            fn pow(self, exp: &u32) -> Self {
+                Self::pow(self, *exp)
+            }
+        }
+
+        impl ::num_traits::Euclid for $t {
+            #[inline(always)]
+            fn div_euclid(&self, v: &Self) -> Self {
+                Self::div_euclid(*self, *v)
+            }
+
+            #[inline(always)]
+            fn rem_euclid(&self, v: &Self) -> Self {
+                Self::rem_euclid(*self, *v)
+            }
+        }
+
+        impl ::num_traits::CheckedEuclid for $t {
+            #[inline(always)]
+            fn checked_div_euclid(&self, v: &Self) -> Option<Self> {
+                Self::checked_div_euclid(*self, *v)
+            }
+
+            #[inline(always)]
+            fn checked_rem_euclid(&self, v: &Self) -> Option<Self> {
+                Self::checked_rem_euclid(*self, *v)
+            }
+        }
+
+        impl ::num_traits::Num for $t {
+            type FromStrRadixErr = $crate::ParseIntError;
+
+            #[inline(always)]
+            fn from_str_radix(src: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
+                Self::from_str_radix(src, radix)
+            }
+        }
+
+        impl ::num_traits::Saturating for $t {
+            #[inline(always)]
+            fn saturating_add(self, v: Self) -> Self {
+                Self::saturating_add(self, v)
+            }
+
+            #[inline(always)]
+            fn saturating_sub(self, v: Self) -> Self {
+                Self::saturating_sub(self, v)
+            }
+        }
+
+        $crate::shared::num_traits_impls::define! {
+            arity 2,
+            type => $t, impl => num_traits::SaturatingAdd, op => saturating_add, out => $t,
+            type => $t, impl => num_traits::SaturatingSub, op => saturating_sub, out => $t,
+            type => $t, impl => num_traits::SaturatingMul, op => saturating_mul, out => $t,
+            type => $t, impl => num_traits::WrappingAdd, op => wrapping_add, out => $t,
+            type => $t, impl => num_traits::WrappingSub, op => wrapping_sub, out => $t,
+            type => $t, impl => num_traits::WrappingMul, op => wrapping_mul, out => $t,
+            type => $t, impl => num_traits::CheckedAdd, op => checked_add, out => Option<$t>,
+            type => $t, impl => num_traits::CheckedSub, op => checked_sub, out => Option<$t>,
+            type => $t, impl => num_traits::CheckedMul, op => checked_mul, out => Option<$t>,
+            type => $t, impl => num_traits::CheckedDiv, op => checked_div, out => Option<$t>,
+            type => $t, impl => num_traits::CheckedRem, op => checked_rem, out => Option<$t>,
+        }
+
+        $crate::shared::num_traits_impls::define! {
+            arity 1,
+            type => $t, impl => num_traits::WrappingNeg, op => wrapping_neg, out => $t,
+            type => $t, impl => num_traits::CheckedNeg, op => checked_neg, out => Option<$t>,
+        }
+
+        $crate::shared::num_traits_impls::define! {
+            arity shift,
+            type => $t, impl => num_traits::WrappingShl, op => wrapping_shl, out => $t,
+            type => $t, impl => num_traits::WrappingShr, op => wrapping_shr, out => $t,
+            type => $t, impl => num_traits::CheckedShl, op => checked_shl, out => Option<$t>,
+            type => $t, impl => num_traits::CheckedShr, op => checked_shr, out => Option<$t>,
+        }
+
+        $crate::shared::num_traits_impls::define! {
+            impl AsPrimitive,
+            in => $t, out => u8, asop => as_u8,
+            in => $t, out => i8, asop => as_i8,
+            in => $t, out => u16, asop => as_u16,
+            in => $t, out => i16, asop => as_i16,
+            in => $t, out => u32, asop => as_u32,
+            in => $t, out => i32, asop => as_i32,
+            in => $t, out => u64, asop => as_u64,
+            in => $t, out => i64, asop => as_i64,
+            in => $t, out => u128, asop => as_u128,
+            in => $t, out => i128, asop => as_i128,
+            in => $t, out => usize, asop => as_u128, extras => as usize,
+            in => $t, out => isize, asop => as_i128, extras => as isize,
+        }
+
+        $crate::shared::num_traits_impls::define! {
+            impl AsPrimitive,
+            in => u8, out => $t, fromop => from_u8,
+            in => i8, out => $t, fromop => from_i8,
+            in => u16, out => $t, fromop => from_u16,
+            in => i16, out => $t, fromop => from_i16,
+            in => u32, out => $t, fromop => from_u32,
+            in => i32, out => $t, fromop => from_i32,
+            in => u64, out => $t, fromop => from_u64,
+            in => i64, out => $t, fromop => from_i64,
+            in => u128, out => $t, fromop => from_u128,
+            in => i128, out => $t, fromop => from_i128,
+            in => usize, out => $t, fromop => from_u128, extras => as u128,
+            in => isize, out => $t, fromop => from_i128, extras => as i128,
+            in => char, out => $t, fromop => from_u32, extras => as u32,
+            in => bool, out => $t, fromop => from_u8, extras => as u8,
+        }
+    };
+}
+
+pub(crate) use define;

--- a/src/shared/ops.rs
+++ b/src/shared/ops.rs
@@ -179,6 +179,10 @@ macro_rules! traits {
             type => $t, impl => core::ops::Shl, op => shl,
             type => $t, impl => core::ops::Shr, op => shr,
         }
+
+        $crate::shared::num_traits_impls::define! {
+            type => $t,
+        }
     };
 }
 

--- a/src/uint/traits.rs
+++ b/src/uint/traits.rs
@@ -170,6 +170,325 @@ macro_rules! define {
                 }
             }
         }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::Unsigned for $t {}
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::FromPrimitive for $t {
+            #[inline]
+            fn from_i8(n: i8) -> Option<Self> {
+                n.try_into().ok().map(Self::from_u8)
+            }
+
+            #[inline]
+            fn from_i16(n: i16) -> Option<Self> {
+                n.try_into().ok().map(Self::from_u16)
+            }
+
+            #[inline]
+            fn from_i32(n: i32) -> Option<Self> {
+                n.try_into().ok().map(Self::from_u32)
+            }
+
+            #[inline]
+            fn from_i64(n: i64) -> Option<Self> {
+                n.try_into().ok().map(Self::from_u64)
+            }
+
+            #[inline]
+            fn from_i128(n: i128) -> Option<Self> {
+                n.try_into().ok().map(Self::from_u128)
+            }
+
+            #[inline]
+            fn from_isize(n: isize) -> Option<Self> {
+                n.try_into().ok().map(Self::from_u128)
+            }
+
+            #[inline(always)]
+            fn from_u8(n: u8) -> Option<Self> {
+                Some(Self::from_u8(n))
+            }
+
+            #[inline(always)]
+            fn from_u16(n: u16) -> Option<Self> {
+                Some(Self::from_u16(n))
+            }
+
+            #[inline(always)]
+            fn from_u32(n: u32) -> Option<Self> {
+                Some(Self::from_u32(n))
+            }
+
+            #[inline(always)]
+            fn from_u64(n: u64) -> Option<Self> {
+                Some(Self::from_u64(n))
+            }
+
+            #[inline(always)]
+            fn from_u128(n: u128) -> Option<Self> {
+                Some(Self::from_u128(n))
+            }
+
+            #[inline(always)]
+            fn from_usize(n: usize) -> Option<Self> {
+                Some(Self::from_u128(n as u128))
+            }
+
+            #[inline]
+            fn from_f32(_: f32) -> Option<Self> {
+                unimplemented!("floating-point conversions")
+            }
+
+            #[inline]
+            fn from_f64(_: f64) -> Option<Self> {
+                unimplemented!("floating-point conversions")
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::ToPrimitive for $t {
+            #[inline]
+            fn to_i8(&self) -> Option<i8> {
+                const ABOVE: $t = <$t>::from_i8(i8::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_i8(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i16(&self) -> Option<i16> {
+                const ABOVE: $t = <$t>::from_i16(i16::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_i16(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i32(&self) -> Option<i32> {
+                const ABOVE: $t = <$t>::from_i32(i32::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_i32(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i64(&self) -> Option<i64> {
+                const ABOVE: $t = <$t>::from_i64(i64::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_i64(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_i128(&self) -> Option<i128> {
+                const ABOVE: $t = <$t>::from_i128(i128::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_i128(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_isize(&self) -> Option<isize> {
+                const ABOVE: $t = <$t>::from_i128(isize::MAX as i128);
+                if *self <= ABOVE {
+                    Some(Self::as_i128(self) as isize)
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u8(&self) -> Option<u8> {
+                const ABOVE: $t = <$t>::from_u8(u8::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_u8(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u16(&self) -> Option<u16> {
+                const ABOVE: $t = <$t>::from_u16(u16::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_u16(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u32(&self) -> Option<u32> {
+                const ABOVE: $t = <$t>::from_u32(u32::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_u32(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u64(&self) -> Option<u64> {
+                const ABOVE: $t = <$t>::from_u64(u64::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_u64(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_u128(&self) -> Option<u128> {
+                const ABOVE: $t = <$t>::from_u128(u128::MAX);
+                if *self <= ABOVE {
+                    Some(Self::as_u128(self))
+                } else {
+                    None
+                }
+            }
+
+            #[inline]
+            fn to_usize(&self) -> Option<usize> {
+                const ABOVE: $t = <$t>::from_u128(usize::MAX as u128);
+                if *self <= ABOVE {
+                    Some(Self::as_u128(self) as usize)
+                } else {
+                    None
+                }
+            }
+
+            #[inline(always)]
+            fn to_f32(&self) -> Option<f32> {
+                unimplemented!("floating-point conversions")
+            }
+
+            #[inline(always)]
+            fn to_f64(&self) -> Option<f64> {
+                unimplemented!("floating-point conversions")
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::NumCast for $t {
+            #[inline]
+            fn from<T: ::num_traits::ToPrimitive>(n: T) -> Option<Self> {
+                if let Some(n128u) = <T as ::num_traits::ToPrimitive>::to_u128(&n) {
+                    <Self as ::num_traits::FromPrimitive>::from_u128(n128u)
+                } else {
+                    None
+                }
+            }
+        }
+
+        #[cfg(feature = "num-traits")]
+        impl ::num_traits::PrimInt for $t {
+            #[inline(always)]
+            fn count_ones(self) -> u32 {
+                Self::count_ones(self)
+            }
+
+            #[inline(always)]
+            fn count_zeros(self) -> u32 {
+                Self::count_zeros(self)
+            }
+
+            #[inline(always)]
+            fn leading_ones(self) -> u32 {
+                Self::leading_ones(self)
+            }
+
+            #[inline(always)]
+            fn leading_zeros(self) -> u32 {
+                Self::leading_zeros(self)
+            }
+
+            #[inline(always)]
+            fn trailing_ones(self) -> u32 {
+                Self::trailing_ones(self)
+            }
+
+            #[inline(always)]
+            fn trailing_zeros(self) -> u32 {
+                Self::trailing_zeros(self)
+            }
+
+            #[inline(always)]
+            fn rotate_left(self, n: u32) -> Self {
+                Self::rotate_left(self, n)
+            }
+
+            #[inline(always)]
+            fn rotate_right(self, n: u32) -> Self {
+                Self::rotate_right(self, n)
+            }
+
+            #[inline(always)]
+            fn signed_shl(self, n: u32) -> Self {
+                (self.cast_signed() << n).cast_unsigned()
+            }
+
+            #[inline(always)]
+            fn signed_shr(self, n: u32) -> Self {
+                (self.cast_signed() >> n).cast_unsigned()
+            }
+
+            #[inline(always)]
+            fn unsigned_shl(self, n: u32) -> Self {
+                self << n
+            }
+
+            #[inline(always)]
+            fn unsigned_shr(self, n: u32) -> Self {
+                self >> n
+            }
+
+            #[inline(always)]
+            fn swap_bytes(self) -> Self {
+                Self::swap_bytes(&self)
+            }
+
+            #[inline(always)]
+            fn from_be(x: Self) -> Self {
+                Self::from_be(x)
+            }
+
+            #[inline(always)]
+            fn from_le(x: Self) -> Self {
+                Self::from_le(x)
+            }
+
+            #[inline(always)]
+            fn to_be(self) -> Self {
+                Self::to_be(self)
+            }
+
+            #[inline(always)]
+            fn to_le(self) -> Self {
+                Self::to_le(self)
+            }
+
+            #[inline(always)]
+            fn reverse_bits(self) -> Self {
+                Self::reverse_bits(&self)
+            }
+
+            #[inline(always)]
+            fn pow(self, exp: u32) -> Self {
+                Self::pow(self, exp)
+            }
+        }
     };
 }
 


### PR DESCRIPTION
As it turns out, this can be done without increasing the MSRV of this crate, since `num-traits` version 0.2.18 is semver-compatible with the latest version and supports Rust 1.59!  These implementations almost all delegate more-or-less directly to the existing inherent methods, but a few (mainly the checked conversions, but also some methods on `Signed`) perform nontrivial work.  I haven't added more inherent methods to cover these, but I can if that would be preferred.  Also, the floating-point conversion methods are left as `unimplemented!()`; I wasn't sure how to handle these in general, since the ranges involved are beyond the primitive integers' ability to represent.

Fixes #19.