### PR TITLE
A few additional methods on unsigned integers

### DIFF
--- a/src/uint/bitops.rs
+++ b/src/uint/bitops.rs
@@ -27,6 +27,62 @@ macro_rules! define {
             let result = $crate::math::shift::right_uwide(self.to_ne_wide(), rhs % Self::BITS);
             Self::from_ne_wide(result)
         }
+
+        /// Returns the minimum number of bits required to represent `self`.
+        ///
+        /// This method returns zero if `self` is zero.
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, bit_width)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        #[inline(always)]
+        pub const fn bit_width(self) -> u32 {
+            Self::BITS - self.leading_zeros()
+        }
+
+        // Implementation detail of `isolate_highest_one`,
+        // but can't be local to that function's body because the compiler
+        // complains about the use of `Self` in local constants.
+        const HIGH_ONE: Self = Self::from_ulimb(1).strict_shl(Self::BITS - 1);
+
+        /// Returns `self` with only the most significant bit set, or `0` if
+        /// the input is `0`.
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, isolate_highest_one)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        #[inline(always)]
+        pub const fn isolate_highest_one(self) -> Self {
+            self.bitand_const(Self::HIGH_ONE.wrapping_shr(self.leading_zeros()))
+        }
+
+        /// Returns `self` with only the least significant bit set, or `0` if
+        /// the input is `0`.
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, isolate_lowest_one)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        #[inline(always)]
+        pub const fn isolate_lowest_one(self) -> Self {
+            self.bitand_const(self.wrapping_neg())
+        }
+
+        /// Returns the index of the highest bit set to one in `self`,
+        /// or `None` if `self` is `0`.
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, highest_one)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        #[inline(always)]
+        pub const fn highest_one(self) -> Option<u32> {
+            (Self::BITS - 1).checked_sub(self.leading_zeros())
+        }
+
+        /// Returns the index of the lowest bit set to one in `self`,
+        /// or `None` if `self` is `0`.
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!($see_t, lowest_one)]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        #[inline(always)]
+        pub const fn lowest_one(self) -> Option<u32> {
+            self.checked_ilog2()
+        }
     };
 }
 

--- a/src/uint/ops.rs
+++ b/src/uint/ops.rs
@@ -314,6 +314,34 @@ macro_rules! define {
 
             (lo, hi)
         }
+
+        /// Calculates the "full multiplication" `self * rhs + carry + add`
+        /// without the possibility to overflow.
+        ///
+        /// This returns the low-order (wrapping) bits and the high-order (overflow) bits
+        /// of the result as two separate values, in that order.
+        ///
+        /// Performs "long multiplication" which takes in an extra amount to add, and may return an
+        /// additional amount of overflow. This allows for chaining together multiple
+        /// multiplications to create "big integers" which represent larger values.
+        ///
+        /// If you don't need the `add`, then you can use [`Self::carrying_mul`] instead.
+        ///
+        #[doc = $crate::shared::docs::primitive_doc!(u64, carrying_mul_add)]
+        #[doc = $crate::shared::docs::nightly_doc!()]
+        #[inline]
+        #[must_use = $crate::shared::docs::must_use_copy_doc!()]
+        pub const fn carrying_mul_add(self, rhs: Self, carry: Self, add: Self) -> (Self, Self) {
+            let lhs = self.to_ne_limbs();
+            let rhs = rhs.to_ne_limbs();
+            let (lo, hi) = $crate::math::mul::widening(&lhs, &rhs);
+            let (lo, overflowed1) = Self::from_ne_limbs(lo).overflowing_add(carry);
+            let (lo, overflowed2) = lo.overflowing_add(add);
+            let overflowed = (overflowed1 as $crate::ULimb) + (overflowed2 as $crate::ULimb);
+            let hi = Self::from_ne_limbs(hi).add_ulimb(overflowed);
+
+            (lo, hi)
+        }
     };
 }
 


### PR DESCRIPTION
`carrying_mul_add`, `bit_width`, and `{,isolate}_{highest,lowest}_one`, all mirrored from Rust's primitive unsigned integers.